### PR TITLE
Calculate status timestamp field name

### DIFF
--- a/lib/course_planner/statuses.ex
+++ b/lib/course_planner/statuses.ex
@@ -3,17 +3,19 @@ defmodule CoursePlanner.Statuses do
     Updates the status timestamps whenever there is a status change in a resource.
     It assumes the resource has a field called status of type CoursePlanner.Types.EntityStatus.
   """
-  import Ecto.Changeset, only: [put_change: 3]
+  import Ecto.Changeset, only: [put_change: 3, get_change: 2]
+  alias CoursePlanner.Types.EntityStatus
+
+  @timestamp_fields Enum.into(
+    EntityStatus.values, %{}, fn status ->
+      {status, :"#{String.downcase(status)}_at"}
+    end)
 
   def update_status_timestamp(changeset) do
-    if changeset.valid? && changeset.changes[:status] do
-      case changeset.changes[:status] do
-        "Planned" -> put_change(changeset, :planned_at, Timex.now)
-        "Active" -> put_change(changeset, :activated_at, Timex.now)
-        "Frozen" -> put_change(changeset, :froze_at, Timex.now)
-        "Finished" -> put_change(changeset, :finished_at, Timex.now)
-        "Deleted" -> put_change(changeset, :deleted_at, Timex.now)
-        _ -> changeset
+    if changeset.valid? && get_change(changeset, :status) do
+      case @timestamp_fields[get_change(changeset, :status)] do
+        nil -> changeset
+        timestamp_field -> put_change(changeset, timestamp_field, Timex.now)
       end
     else
       changeset

--- a/lib/course_planner/statuses.ex
+++ b/lib/course_planner/statuses.ex
@@ -1,6 +1,7 @@
 defmodule CoursePlanner.Statuses do
   @moduledoc """
-    Updates the status timestamps whenever there is a status change in a resource
+    Updates the status timestamps whenever there is a status change in a resource.
+    It assumes the resource has a field called status of type CoursePlanner.Types.EntityStatus.
   """
   import Ecto.Changeset, only: [put_change: 3]
 

--- a/priv/repo/migrations/20170424120050_rename_terms_status_timestamps.exs
+++ b/priv/repo/migrations/20170424120050_rename_terms_status_timestamps.exs
@@ -1,0 +1,8 @@
+defmodule CoursePlanner.Repo.Migrations.RenameTermsStatusTimestamps do
+  use Ecto.Migration
+
+  def change do
+    rename table(:terms), :activated_at, to: :active_at
+    rename table(:terms), :froze_at, to: :frozen_at
+  end
+end

--- a/test/lib/course_planner/statuses_test.exs
+++ b/test/lib/course_planner/statuses_test.exs
@@ -1,0 +1,49 @@
+defmodule CoursePlanner.DummySchema do
+  use CoursePlanner.Web, :model
+
+  embedded_schema do
+    field :name, :string
+    field :status, :string
+  end
+
+  def changeset(struct, params \\ %{}) do
+    cast(struct, params, [:name, :status])
+  end
+end
+
+defmodule CoursePlanner.StatusesTest do
+  use CoursePlanner.ModelCase
+
+  alias CoursePlanner.{DummySchema, Statuses}
+  alias Ecto.Changeset
+
+  test "do nothing when changeset is invalid" do
+    changeset =
+      %DummySchema{}
+      |> DummySchema.changeset()
+      |> Changeset.add_error(:name, "error")
+
+    refute changeset.valid?
+    assert changeset == Statuses.update_status_timestamp(changeset)
+  end
+
+  test "do nothing when there is no status change" do
+    changeset = DummySchema.changeset(%DummySchema{})
+
+    assert Changeset.get_change(changeset, :status) == nil
+    assert changeset == Statuses.update_status_timestamp(changeset)
+  end
+
+  test "do nothing when the status is not one of EntityStatus values" do
+    changeset = DummySchema.changeset(%DummySchema{}, %{status: "Dummy"})
+    assert changeset == Statuses.update_status_timestamp(changeset)
+  end
+
+  test "set timestamp status when the status is one of EntityStatus values" do
+    changeset = DummySchema.changeset(%DummySchema{}, %{status: "Active"})
+    assert Changeset.get_change(changeset, :activated_at) == nil
+
+    changeset = Statuses.update_status_timestamp(changeset)
+    refute Changeset.get_change(changeset, :activated_at) == nil
+  end
+end

--- a/test/lib/course_planner/statuses_test.exs
+++ b/test/lib/course_planner/statuses_test.exs
@@ -41,9 +41,9 @@ defmodule CoursePlanner.StatusesTest do
 
   test "set timestamp status when the status is one of EntityStatus values" do
     changeset = DummySchema.changeset(%DummySchema{}, %{status: "Active"})
-    assert Changeset.get_change(changeset, :activated_at) == nil
+    assert Changeset.get_change(changeset, :active_at) == nil
 
     changeset = Statuses.update_status_timestamp(changeset)
-    refute Changeset.get_change(changeset, :activated_at) == nil
+    refute Changeset.get_change(changeset, :active_at) == nil
   end
 end

--- a/web/models/terms/term.ex
+++ b/web/models/terms/term.ex
@@ -16,8 +16,8 @@ defmodule CoursePlanner.Terms.Term do
 
     field :status, EntityStatus
     field :planned_at, :naive_datetime
-    field :activated_at, :naive_datetime
-    field :froze_at, :naive_datetime
+    field :active_at, :naive_datetime
+    field :frozen_at, :naive_datetime
     field :finished_at, :naive_datetime
     field :deleted_at, :naive_datetime
 


### PR DESCRIPTION
Refactor `CoursePlanner.Statuses.update_status_timestamp/1` to calculate
the possible timestamp field names from the enum type
`CoursePlanner.Types.EntityStatus`