### PR TITLE
Generalize Enum type

### DIFF
--- a/lib/course_planner/enum.ex
+++ b/lib/course_planner/enum.ex
@@ -1,11 +1,11 @@
-defmodule EnumTimestamp do
+defmodule CoursePlanner.Enum do
   @moduledoc """
   Behaviour to represent Enum with mapping to timestamp
   """
   defmacro __using__(_) do
     quote do
       @behaviour Ecto.Type
-      @behaviour EnumTimestamp
+      @behaviour CoursePlanner.Enum
       @callback valid_types :: [String.t]
       def cast(value) do
         if Enum.member?(valid_types(), value), do: {:ok, value}, else: :error

--- a/lib/course_planner/statuses.ex
+++ b/lib/course_planner/statuses.ex
@@ -1,19 +1,12 @@
 defmodule CoursePlanner.Statuses do
   @moduledoc """
     Updates the status timestamps whenever there is a status change in a resource.
-    It assumes the resource has a field called status of type CoursePlanner.Types.EntityStatus.
   """
   import Ecto.Changeset, only: [put_change: 3, get_change: 2]
-  alias CoursePlanner.Types.EntityStatus
 
-  @timestamp_fields Enum.into(
-    EntityStatus.values, %{}, fn status ->
-      {status, :"#{String.downcase(status)}_at"}
-    end)
-
-  def update_status_timestamp(changeset) do
+  def update_status_timestamp(changeset, vals) do
     if changeset.valid? && get_change(changeset, :status) do
-      case @timestamp_fields[get_change(changeset, :status)] do
+      case vals[get_change(changeset, :status)] do
         nil -> changeset
         timestamp_field -> put_change(changeset, timestamp_field, Timex.now)
       end

--- a/lib/course_planner/statuses.ex
+++ b/lib/course_planner/statuses.ex
@@ -4,9 +4,9 @@ defmodule CoursePlanner.Statuses do
   """
   import Ecto.Changeset, only: [put_change: 3, get_change: 2]
 
-  def update_status_timestamp(changeset, vals) do
+  def update_status_timestamp(changeset, enum_timestamp) do
     if changeset.valid? && get_change(changeset, :status) do
-      case vals[get_change(changeset, :status)] do
+      case enum_timestamp.types_timestamp()[get_change(changeset, :status)] do
         nil -> changeset
         timestamp_field -> put_change(changeset, timestamp_field, Timex.now)
       end

--- a/lib/course_planner/student_status.ex
+++ b/lib/course_planner/student_status.ex
@@ -2,7 +2,7 @@ defmodule CoursePlanner.StudentStatus do
   @moduledoc """
     This module represents the possible student statuses
   """
-  use EnumTimestamp
+  use CoursePlanner.Enum
 
   def type, do: :student_status
   def valid_types, do: ["Active", "Graduated", "Frozen"]

--- a/lib/course_planner/student_status.ex
+++ b/lib/course_planner/student_status.ex
@@ -1,0 +1,9 @@
+defmodule CoursePlanner.StudentStatus do
+  @moduledoc """
+    This module represents the possible student statuses
+  """
+  use EnumTimestamp
+
+  def type, do: :student_status
+  def valid_types, do: ["Active", "Graduated", "Frozen"]
+end

--- a/lib/enum_timestamp.ex
+++ b/lib/enum_timestamp.ex
@@ -2,6 +2,25 @@ defmodule EnumTimestamp do
   @moduledoc """
   Behaviour to represent Enum with mapping to timestamp
   """
-  @callback valid_types() :: [String.t]
-  @callback types_timestamp() :: [{String.t, atom()}]
+  defmacro __using__(_) do
+    quote do
+      @behaviour Ecto.Type
+      @behaviour EnumTimestamp
+      @callback valid_types :: [String.t]
+      def cast(value) do
+        if Enum.member?(valid_types(), value), do: {:ok, value}, else: :error
+      end
+
+      def load(value), do: {:ok, value}
+
+      def dump(value) do
+        if Enum.member?(valid_types(), value), do: {:ok, value}, else: :error
+      end
+
+      def types_timestamp do
+        Enum.into(valid_types(), %{}, &({&1, :"#{String.downcase(&1)}_at"}))
+      end
+      defoverridable types_timestamp: 0
+    end
+  end
 end

--- a/lib/enum_timestamp.ex
+++ b/lib/enum_timestamp.ex
@@ -1,0 +1,4 @@
+defmodule EnumTimestamp do
+  @callback valid_types() :: [String.t]
+  @callback types_timestamp() :: [{String.t, atom()}]
+end

--- a/lib/enum_timestamp.ex
+++ b/lib/enum_timestamp.ex
@@ -1,4 +1,7 @@
 defmodule EnumTimestamp do
+  @moduledoc """
+  Behaviour to represent Enum with mapping to timestamp
+  """
   @callback valid_types() :: [String.t]
   @callback types_timestamp() :: [{String.t, atom()}]
 end

--- a/priv/repo/migrations/20170503181307_rename_user_status.exs
+++ b/priv/repo/migrations/20170503181307_rename_user_status.exs
@@ -1,0 +1,8 @@
+defmodule CoursePlanner.Repo.Migrations.RenameUserStatus do
+  use Ecto.Migration
+
+  def change do
+    rename table(:users), :activated_at, to: :active_at
+    rename table(:users), :froze_at, to: :frozen_at
+  end
+end

--- a/priv/repo/migrations/20170504140508_change_timestamp_type.exs
+++ b/priv/repo/migrations/20170504140508_change_timestamp_type.exs
@@ -1,0 +1,19 @@
+defmodule CoursePlanner.Repo.Migrations.ChangeTimestampType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      remove :deleted_at
+      remove :active_at
+      remove :frozen_at
+      remove :graduated_at
+    end
+
+    alter table(:users) do
+      add :deleted_at, :naive_datetime
+      add :active_at, :naive_datetime
+      add :frozen_at, :naive_datetime
+      add :graduated_at, :naive_datetime
+    end
+  end
+end

--- a/test/lib/course_planner/statuses_test.exs
+++ b/test/lib/course_planner/statuses_test.exs
@@ -18,8 +18,6 @@ defmodule CoursePlanner.StatusesTest do
   alias Ecto.Changeset
   alias CoursePlanner.Types.EntityStatus
 
-  @values EntityStatus.timestamp_field
-
   test "do nothing when changeset is invalid" do
     changeset =
       %DummySchema{}
@@ -28,26 +26,26 @@ defmodule CoursePlanner.StatusesTest do
 
     refute changeset.valid?
 
-    assert changeset == Statuses.update_status_timestamp(changeset, @values)
+    assert changeset == Statuses.update_status_timestamp(changeset, EntityStatus)
   end
 
   test "do nothing when there is no status change" do
     changeset = DummySchema.changeset(%DummySchema{})
 
     assert Changeset.get_change(changeset, :status) == nil
-    assert changeset == Statuses.update_status_timestamp(changeset, @values)
+    assert changeset == Statuses.update_status_timestamp(changeset, EntityStatus)
   end
 
   test "do nothing when the status is not one of EntityStatus values" do
     changeset = DummySchema.changeset(%DummySchema{}, %{status: "Dummy"})
-    assert changeset == Statuses.update_status_timestamp(changeset, @values)
+    assert changeset == Statuses.update_status_timestamp(changeset, EntityStatus)
   end
 
   test "set timestamp status when the status is one of EntityStatus values" do
     changeset = DummySchema.changeset(%DummySchema{}, %{status: "Active"})
     assert Changeset.get_change(changeset, :active_at) == nil
 
-    changeset = Statuses.update_status_timestamp(changeset, @values)
+    changeset = Statuses.update_status_timestamp(changeset, EntityStatus)
     refute Changeset.get_change(changeset, :active_at) == nil
   end
 end

--- a/test/lib/course_planner/statuses_test.exs
+++ b/test/lib/course_planner/statuses_test.exs
@@ -16,6 +16,9 @@ defmodule CoursePlanner.StatusesTest do
 
   alias CoursePlanner.{DummySchema, Statuses}
   alias Ecto.Changeset
+  alias CoursePlanner.Types.EntityStatus
+
+  @values EntityStatus.timestamp_field
 
   test "do nothing when changeset is invalid" do
     changeset =
@@ -24,26 +27,27 @@ defmodule CoursePlanner.StatusesTest do
       |> Changeset.add_error(:name, "error")
 
     refute changeset.valid?
-    assert changeset == Statuses.update_status_timestamp(changeset)
+
+    assert changeset == Statuses.update_status_timestamp(changeset, @values)
   end
 
   test "do nothing when there is no status change" do
     changeset = DummySchema.changeset(%DummySchema{})
 
     assert Changeset.get_change(changeset, :status) == nil
-    assert changeset == Statuses.update_status_timestamp(changeset)
+    assert changeset == Statuses.update_status_timestamp(changeset, @values)
   end
 
   test "do nothing when the status is not one of EntityStatus values" do
     changeset = DummySchema.changeset(%DummySchema{}, %{status: "Dummy"})
-    assert changeset == Statuses.update_status_timestamp(changeset)
+    assert changeset == Statuses.update_status_timestamp(changeset, @values)
   end
 
   test "set timestamp status when the status is one of EntityStatus values" do
     changeset = DummySchema.changeset(%DummySchema{}, %{status: "Active"})
     assert Changeset.get_change(changeset, :active_at) == nil
 
-    changeset = Statuses.update_status_timestamp(changeset)
+    changeset = Statuses.update_status_timestamp(changeset, @values)
     refute Changeset.get_change(changeset, :active_at) == nil
   end
 end

--- a/web/models/coherence/user.ex
+++ b/web/models/coherence/user.ex
@@ -8,8 +8,8 @@ defmodule CoursePlanner.User do
   @target_params [
       :name, :family_name, :nickname,
       :email, :student_id, :comments,
-      :role, :deleted_at, :status,
-      :participation_type, :phone_number
+      :role, :status, :participation_type,
+      :phone_number
     ]
 
   schema "users" do
@@ -24,8 +24,8 @@ defmodule CoursePlanner.User do
     field :deleted_at, Ecto.DateTime
     field :status, EntityStatus
     field :participation_type, ParticipationType
-    field :activated_at, Ecto.DateTime
-    field :froze_at, Ecto.DateTime
+    field :active_at, Ecto.DateTime
+    field :frozen_at, Ecto.DateTime
     field :graduated_at, Ecto.DateTime
 
     coherence_schema()

--- a/web/models/coherence/user.ex
+++ b/web/models/coherence/user.ex
@@ -21,12 +21,12 @@ defmodule CoursePlanner.User do
     field :student_id, :string
     field :comments, :string
     field :role, UserRole
-    field :deleted_at, Ecto.DateTime
+    field :deleted_at, :naive_datetime
     field :status, EntityStatus
     field :participation_type, ParticipationType
-    field :active_at, Ecto.DateTime
-    field :frozen_at, Ecto.DateTime
-    field :graduated_at, Ecto.DateTime
+    field :active_at, :naive_datetime
+    field :frozen_at, :naive_datetime
+    field :graduated_at, :naive_datetime
 
     coherence_schema()
     timestamps()

--- a/web/models/students.ex
+++ b/web/models/students.ex
@@ -5,7 +5,8 @@ defmodule CoursePlanner.Students do
   alias CoursePlanner.Repo
   alias CoursePlanner.User
   import Ecto.Query
-  alias Ecto.{Changeset, DateTime}
+  alias CoursePlanner.Types.EntityStatus
+  alias CoursePlanner.Statuses
 
   @students from u in User, where: u.role == "Student" and is_nil(u.deleted_at)
 
@@ -19,25 +20,11 @@ defmodule CoursePlanner.Students do
       student ->
         student
         |> User.changeset(params)
-        |> add_timestamps()
+        |> Statuses.update_status_timestamp(EntityStatus)
         |> Repo.update
         |> format_error(student)
     end
   end
-
-  defp add_timestamps(%{changes: %{status: "Graduated"}} = changeset) do
-    Changeset.put_change(changeset, :graduated_at, DateTime.utc())
-  end
-
-  defp add_timestamps(%{changes: %{status: "Active"}} = changeset) do
-    Changeset.put_change(changeset, :activated_at, DateTime.utc())
-  end
-
-  defp add_timestamps(%{changes: %{status: "Frozen"}} = changeset) do
-    Changeset.put_change(changeset, :froze_at, DateTime.utc())
-  end
-
-  defp add_timestamps(changeset), do: changeset
 
   defp format_error({:ok, student}, _), do: {:ok, student}
   defp format_error({:error, changeset}, student), do: {:error, student, changeset}

--- a/web/models/students.ex
+++ b/web/models/students.ex
@@ -5,8 +5,8 @@ defmodule CoursePlanner.Students do
   alias CoursePlanner.Repo
   alias CoursePlanner.User
   import Ecto.Query
-  alias CoursePlanner.Types.EntityStatus
   alias CoursePlanner.Statuses
+  alias CoursePlanner.StudentStatus
 
   @students from u in User, where: u.role == "Student" and is_nil(u.deleted_at)
 
@@ -20,7 +20,7 @@ defmodule CoursePlanner.Students do
       student ->
         student
         |> User.changeset(params)
-        |> Statuses.update_status_timestamp(EntityStatus)
+        |> Statuses.update_status_timestamp(StudentStatus)
         |> Repo.update
         |> format_error(student)
     end

--- a/web/models/terms/term.ex
+++ b/web/models/terms/term.ex
@@ -29,6 +29,6 @@ defmodule CoursePlanner.Terms.Term do
     |> cast(params, [:name, :start_date, :end_date, :status])
     |> validate_required([:name, :start_date, :end_date, :status])
     |> cast_embed(:holidays)
-    |> Statuses.update_status_timestamp()
+    |> Statuses.update_status_timestamp(EntityStatus.timestamp_field())
   end
 end

--- a/web/models/terms/term.ex
+++ b/web/models/terms/term.ex
@@ -29,6 +29,6 @@ defmodule CoursePlanner.Terms.Term do
     |> cast(params, [:name, :start_date, :end_date, :status])
     |> validate_required([:name, :start_date, :end_date, :status])
     |> cast_embed(:holidays)
-    |> Statuses.update_status_timestamp(EntityStatus.timestamp_field())
+    |> Statuses.update_status_timestamp(EntityStatus)
   end
 end

--- a/web/models/types/entity_status.ex
+++ b/web/models/types/entity_status.ex
@@ -24,4 +24,12 @@ defmodule CoursePlanner.Types.EntityStatus do
       :false -> :error
     end
   end
+
+  def timestamp_field do
+    Enum.into(
+      values, %{}, fn status ->
+        {status, :"#{String.downcase(status)}_at"}
+      end)
+  end
+
 end

--- a/web/models/types/entity_status.ex
+++ b/web/models/types/entity_status.ex
@@ -3,33 +3,26 @@ defmodule CoursePlanner.Types.EntityStatus do
     This module introduces a custom type for Etco for checking status in the model
   """
   @behaviour Ecto.Type
+  @behaviour EnumTimestamp
   def type, do: :entity_status
 
   @valid_entity_types ["Planned", "Active", "Finished", "Graduated", "Frozen"]
 
+  def valid_entity_types, do: @valid_entity_types
+
   def values, do: @valid_entity_types
 
-  def cast(value) do
-    case Enum.member?(@valid_entity_types, value) do
-      :true  -> {:ok, value}
-      :false -> :error
-    end
-  end
+  def cast(value) when value in @valid_entity_types, do: {:ok, value}
+  def cast(_value), do: :error
 
   def load(value), do: {:ok, value}
 
-  def dump(value) do
-    case Enum.member?(@valid_entity_types, value) do
-      :true  -> {:ok, value}
-      :false -> :error
-    end
-  end
+  def dump(value) when value in @valid_entity_types, do: {:ok, value}
+  def dump(_value), do: :error
 
-  def timestamp_field do
-    Enum.into(
-      values, %{}, fn status ->
-        {status, :"#{String.downcase(status)}_at"}
-      end)
+  def valid_types, do: @valid_entity_types
+  def types_timestamp do
+    Enum.into(valid_types(), %{}, &({&1, :"#{String.downcase(&1)}_at"}))
   end
 
 end

--- a/web/models/types/entity_status.ex
+++ b/web/models/types/entity_status.ex
@@ -2,27 +2,9 @@ defmodule CoursePlanner.Types.EntityStatus do
   @moduledoc """
     This module introduces a custom type for Etco for checking status in the model
   """
-  @behaviour Ecto.Type
-  @behaviour EnumTimestamp
+  use EnumTimestamp
+
   def type, do: :entity_status
-
-  @valid_entity_types ["Planned", "Active", "Finished", "Graduated", "Frozen"]
-
-  def valid_entity_types, do: @valid_entity_types
-
-  def values, do: @valid_entity_types
-
-  def cast(value) when value in @valid_entity_types, do: {:ok, value}
-  def cast(_value), do: :error
-
-  def load(value), do: {:ok, value}
-
-  def dump(value) when value in @valid_entity_types, do: {:ok, value}
-  def dump(_value), do: :error
-
-  def valid_types, do: @valid_entity_types
-  def types_timestamp do
-    Enum.into(valid_types(), %{}, &({&1, :"#{String.downcase(&1)}_at"}))
-  end
+  def valid_types, do: ["Planned", "Active", "Finished", "Graduated", "Frozen"]
 
 end

--- a/web/models/types/entity_status.ex
+++ b/web/models/types/entity_status.ex
@@ -2,7 +2,7 @@ defmodule CoursePlanner.Types.EntityStatus do
   @moduledoc """
     This module introduces a custom type for Etco for checking status in the model
   """
-  use EnumTimestamp
+  use CoursePlanner.Enum
 
   def type, do: :entity_status
   def valid_types, do: ["Planned", "Active", "Finished", "Graduated", "Frozen"]


### PR DESCRIPTION
Define a behaviour to help using Enum types easier, with an optional helper with the timestamp.
As you can see in `EntityStatus`, it's cleaner to define an Enum to be used. The schema type could still be an `EntityStatus` but a subset could be passed to restrict the choosable types (see `CoursePlanner.Students` and `CoursePlanner.StudentStatus`).