### PR TITLE
Change datetime types to naive_datetime

### DIFF
--- a/priv/repo/migrations/20170504140508_change_timestamp_type.exs
+++ b/priv/repo/migrations/20170504140508_change_timestamp_type.exs
@@ -1,0 +1,19 @@
+defmodule CoursePlanner.Repo.Migrations.ChangeTimestampType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      remove :deleted_at
+      remove :active_at
+      remove :frozen_at
+      remove :graduated_at
+    end
+
+    alter table(:users) do
+      add :deleted_at, :naive_datetime
+      add :active_at, :naive_datetime
+      add :frozen_at, :naive_datetime
+      add :graduated_at, :naive_datetime
+    end
+  end
+end

--- a/web/models/coherence/user.ex
+++ b/web/models/coherence/user.ex
@@ -21,12 +21,12 @@ defmodule CoursePlanner.User do
     field :student_id, :string
     field :comments, :string
     field :role, UserRole
-    field :deleted_at, Ecto.DateTime
+    field :deleted_at, :naive_datetime
     field :status, EntityStatus
     field :participation_type, ParticipationType
-    field :activated_at, Ecto.DateTime
-    field :froze_at, Ecto.DateTime
-    field :graduated_at, Ecto.DateTime
+    field :activated_at, :naive_datetime
+    field :froze_at, :naive_datetime
+    field :graduated_at, :naive_datetime
 
     coherence_schema()
     timestamps()


### PR DESCRIPTION
Change `Ecto.DateTime` types to `:naive_datetime` as discussed in this [PR](https://github.com/digitalnatives/course_planner/pull/19).
Coherence's types shouldn't bother too much, having naive datetime should be simpler for this project.