### PR TITLE
Fix asset reloading in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,4 @@ RUN mix local.hex --force \
 RUN mkdir /myapp
 WORKDIR /myapp
 
-ADD mix.* /myapp/
-RUN mix deps.get
-RUN mix deps.compile
-
-ADD package.json /myapp/
-RUN npm install
-
-ADD . /myapp/
-RUN mix compile
-
 CMD iex

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -13,9 +13,9 @@ services:
     environment:
       - DATABASE_HOST=db
     volumes:
-      - .:/myapp-dev
+      - .:/myapp
     ports:
       - 4000:4000
     depends_on:
       - db
-    working_dir: /myapp-dev
+    working_dir: /myapp

--- a/scripts/docker-compose-up.sh.sample
+++ b/scripts/docker-compose-up.sh.sample
@@ -1,23 +1,12 @@
 #! /bin/bash
 
-if [ ! -d "/myapp-dev/deps" ]; then
-  >&2 echo "creating symbolic link to the container original 'deps'"
-  ln -s /myapp/deps /myapp-dev/.
-fi
-if [ ! -d "/myapp-dev/_build" ]; then
-  >&2 echo "creating symbolic link to the container original '_build'"
-  ln -s /myapp/_build /myapp-dev/.
-fi
-if [ ! -d "/myapp-dev/node_modules" ]; then
-  >&2 echo "creating symbolic link to the container original 'node_modules'"
-  ln -s /myapp/node_modules /myapp-dev/.
-fi
-
 until pg_isready -h "db"; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done
 >&2 echo "Postgres is up - executing command"
 
+mix deps.get
+npm install
 mix ecto.setup
 mix phoenix.server


### PR DESCRIPTION
The watchers could not work with the symlinks, so they are removed.
The dependencies and compilation are removed from the image because they
can't be reused.
Now it uses the current workdir for deps, build and node_modules.