### PR TITLE
Send resource link in e-mail notifications

### DIFF
--- a/lib/course_planner/mailer/user_email.ex
+++ b/lib/course_planner/mailer/user_email.ex
@@ -15,8 +15,8 @@ defmodule CoursePlanner.Mailer.UserEmail do
     class_deleted: %{subject: "A class you subscribe to was deleted", template: "class_deleted.html"},
   }
 
-  def build_email(%{name: _, email: nil}, _), do: {:error, :invalid_recipient}
-  def build_email(%{name: name, email: email}, notification_type) do
+  def build_email(%{name: _, email: nil}, _, _), do: {:error, :invalid_recipient}
+  def build_email(%{name: name, email: email}, notification_type, path) do
     case @notifications[notification_type] do
       nil -> {:error, :wrong_notification_type}
       params ->
@@ -24,7 +24,7 @@ defmodule CoursePlanner.Mailer.UserEmail do
         |> from("admin@courseplanner.com")
         |> to(email)
         |> subject(params.subject)
-        |> render_body(params.template, %{name: name})
+        |> render_body(params.template, %{name: name, path: path})
     end
   end
 end

--- a/lib/course_planner/mailer/user_email.ex
+++ b/lib/course_planner/mailer/user_email.ex
@@ -15,9 +15,9 @@ defmodule CoursePlanner.Mailer.UserEmail do
     class_deleted: %{subject: "A class you subscribe to was deleted", template: "class_deleted.html"},
   }
 
-  def build_email(%{name: _, email: nil}, _, _), do: {:error, :invalid_recipient}
-  def build_email(%{name: name, email: email}, notification_type, path) do
-    case @notifications[notification_type] do
+  def build_email(%{to: %{name: _, email: nil}}), do: {:error, :invalid_recipient}
+  def build_email(%{to: %{name: name, email: email}, type: type, resource_path: path}) do
+    case @notifications[type] do
       nil -> {:error, :wrong_notification_type}
       params ->
         new()

--- a/lib/course_planner/notifier.ex
+++ b/lib/course_planner/notifier.ex
@@ -33,13 +33,13 @@ defmodule CoursePlanner.Notifier do
   end
 
   @spec handle_cast({atom(), Notification.t}, any()) :: {:noreply, any()}
-  def handle_cast({:send_email, %{to: user, type: type, resource_path: path}}, state) do
-    email = UserEmail.build_email(user, type, path)
+  def handle_cast({:send_email, notification}, state) do
+    email = UserEmail.build_email(notification)
     case Mailer.deliver(email) do
       {:ok, _} ->
         {:noreply, state}
       {:error, reason} ->
-        Logger.error("Email delivery failed: #{reason}")
+        Logger.error("Email delivery failed: #{Kernel.inspect reason}")
         {:noreply, [{:error, reason, email} | state]}
     end
   end

--- a/lib/course_planner/notifier.ex
+++ b/lib/course_planner/notifier.ex
@@ -11,14 +11,14 @@ defmodule CoursePlanner.Notifier do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @spec notify_user(User, atom()) :: GenServer.cast
-  def notify_user(%User{} = user, notification_type) do
-    GenServer.cast(__MODULE__, {:send, user, notification_type})
+  @spec notify_user(User, atom(), String.t) :: GenServer.cast
+  def notify_user(%User{} = user, notification_type, path \\ "/") do
+    GenServer.cast(__MODULE__, {:send, user, notification_type, path})
   end
 
-  @spec handle_cast({atom(), User, atom()}, any()) :: {:noreply, any()}
-  def handle_cast({:send, user, notification_type}, state) do
-    email = UserEmail.build_email(user, notification_type)
+  @spec handle_cast({atom(), User, atom(), String.t}, any()) :: {:noreply, any()}
+  def handle_cast({:send, user, notification_type, path}, state) do
+    email = UserEmail.build_email(user, notification_type, path)
     case Mailer.deliver(email) do
       {:ok, _} ->
         {:noreply, state}

--- a/lib/course_planner/notifier.ex
+++ b/lib/course_planner/notifier.ex
@@ -6,19 +6,35 @@ defmodule CoursePlanner.Notifier do
   alias CoursePlanner.{User, Mailer, Mailer.UserEmail}
   require Logger
 
+  defmodule Notification do
+    @moduledoc "Notification struct to be used by Notifier"
+    defstruct type: nil, resource_path: "/", to: nil
+
+    def new, do: %Notification{}
+
+    def type(%Notification{} = notification, type) when is_atom(type),
+      do: %{notification | type: type}
+
+    def resource_path(%Notification{} = notification, path) when is_binary(path),
+      do: %{notification | resource_path: path}
+
+    def to(%Notification{} = notification, %User{} = user),
+      do: %{notification | to: user}
+  end
+
   @spec start_link :: GenServer.start_link
   def start_link do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @spec notify_user(User, atom(), String.t) :: GenServer.cast
-  def notify_user(%User{} = user, notification_type, path \\ "/") do
-    GenServer.cast(__MODULE__, {:send, user, notification_type, path})
+  @spec notify_user(Notification.t) :: GenServer.cast
+  def notify_user(%Notification{} = notification) do
+    GenServer.cast(__MODULE__, {:send_email, notification})
   end
 
-  @spec handle_cast({atom(), User, atom(), String.t}, any()) :: {:noreply, any()}
-  def handle_cast({:send, user, notification_type, path}, state) do
-    email = UserEmail.build_email(user, notification_type, path)
+  @spec handle_cast({atom(), Notification.t}, any()) :: {:noreply, any()}
+  def handle_cast({:send_email, %{to: user, type: type, resource_path: path}}, state) do
+    email = UserEmail.build_email(user, type, path)
     case Mailer.deliver(email) do
       {:ok, _} ->
         {:noreply, state}

--- a/lib/course_planner/users.ex
+++ b/lib/course_planner/users.ex
@@ -2,7 +2,7 @@ defmodule CoursePlanner.Users do
   @moduledoc """
     Handle all interactions with Users, create, list, fetch, edit, and delete
   """
-  alias CoursePlanner.{Repo, User, Notifier}
+  alias CoursePlanner.{Repo, User, Notifier, Notifier.Notification}
   alias Ecto.{Changeset, DateTime}
 
   def new_user(user, token) do
@@ -35,6 +35,10 @@ defmodule CoursePlanner.Users do
 
   def notify_user(%{id: id}, %{id: id}, _, _), do: nil
   def notify_user(modified_user, _current_user, notification_type, path) do
-    Notifier.notify_user(modified_user, notification_type, path)
+    Notification.new()
+    |> Notification.type(notification_type)
+    |> Notification.resource_path(path)
+    |> Notification.to(modified_user)
+    |> Notifier.notify_user()
   end
 end

--- a/lib/course_planner/users.ex
+++ b/lib/course_planner/users.ex
@@ -33,8 +33,8 @@ defmodule CoursePlanner.Users do
     end
   end
 
-  def notify_user(%{id: id}, %{id: id}, _), do: nil
-  def notify_user(modified_user, _current_user, notification_type) do
-    Notifier.notify_user(modified_user, notification_type)
+  def notify_user(%{id: id}, %{id: id}, _, _), do: nil
+  def notify_user(modified_user, _current_user, notification_type, path) do
+    Notifier.notify_user(modified_user, notification_type, path)
   end
 end

--- a/test/lib/course_planner/user_email_test.exs
+++ b/test/lib/course_planner/user_email_test.exs
@@ -10,69 +10,69 @@ defmodule CoursePlanner.UserEmailTest do
   @invalid_user2 %User{name: "mahname", email: nil}
 
   test "inexistent notification type" do
-    assert UserEmail.build_email(@valid_user, :sometype) == {:error, :wrong_notification_type}
+    assert UserEmail.build_email(@valid_user, :sometype, "/") == {:error, :wrong_notification_type}
   end
 
   test "empty e-mail" do
-    assert UserEmail.build_email(@invalid_user, :user_modified) == {:error, :invalid_recipient}
+    assert UserEmail.build_email(@invalid_user, :user_modified, "/") == {:error, :invalid_recipient}
   end
 
   test "nil e-mail" do
-    assert UserEmail.build_email(@invalid_user2, :user_modified) == {:error, :invalid_recipient}
+    assert UserEmail.build_email(@invalid_user2, :user_modified, "/") == {:error, :invalid_recipient}
   end
 
   test "notify user update" do
     @valid_user
-    |> UserEmail.build_email(:user_modified)
+    |> UserEmail.build_email(:user_modified, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "Your profile is updated"
   end
 
   test "notify course update" do
     @valid_user
-    |> UserEmail.build_email(:course_updated)
+    |> UserEmail.build_email(:course_updated, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "A course you subscribed to was updated"
   end
 
   test "notify course deleted" do
     @valid_user
-    |> UserEmail.build_email(:course_deleted)
+    |> UserEmail.build_email(:course_deleted, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "A course you subscribed to was deleted"
   end
 
   test "notify term updated" do
     @valid_user
-    |> UserEmail.build_email(:term_updated)
+    |> UserEmail.build_email(:term_updated, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "A term you are enrolled in was updated"
   end
 
   test "notify term deleted" do
     @valid_user
-    |> UserEmail.build_email(:term_deleted)
+    |> UserEmail.build_email(:term_deleted, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "A term you are enrolled in was deleted"
   end
 
   test "notify class subscription" do
     @valid_user
-    |> UserEmail.build_email(:class_subscribed)
+    |> UserEmail.build_email(:class_subscribed, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "You were subscribed to a class"
   end
 
   test "notify class updated" do
     @valid_user
-    |> UserEmail.build_email(:class_updated)
+    |> UserEmail.build_email(:class_updated, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "A class you subscribe to was updated"
   end
 
   test "notify class deleted" do
     @valid_user
-    |> UserEmail.build_email(:class_deleted)
+    |> UserEmail.build_email(:class_deleted, "/")
     |> Mailer.deliver()
     assert_email_sent subject: "A class you subscribe to was deleted"
   end

--- a/test/lib/course_planner/user_email_test.exs
+++ b/test/lib/course_planner/user_email_test.exs
@@ -2,7 +2,7 @@ defmodule CoursePlanner.UserEmailTest do
   use ExUnit.Case
   doctest CoursePlanner.Mailer.UserEmail
 
-  alias CoursePlanner.{User, Mailer, Mailer.UserEmail}
+  alias CoursePlanner.{User, Mailer, Mailer.UserEmail, Notifier.Notification}
   import Swoosh.TestAssertions
 
   @valid_user %User{name: "mahname", email: "valid@email"}
@@ -10,69 +10,85 @@ defmodule CoursePlanner.UserEmailTest do
   @invalid_user2 %User{name: "mahname", email: nil}
 
   test "inexistent notification type" do
-    assert UserEmail.build_email(@valid_user, :sometype, "/") == {:error, :wrong_notification_type}
+    assert UserEmail.build_email(%Notification{to: @valid_user, type: :sometype}) == {:error, :wrong_notification_type}
   end
 
   test "empty e-mail" do
-    assert UserEmail.build_email(@invalid_user, :user_modified, "/") == {:error, :invalid_recipient}
+    assert UserEmail.build_email(%Notification{to: @invalid_user, type: :user_modified}) == {:error, :invalid_recipient}
   end
 
   test "nil e-mail" do
-    assert UserEmail.build_email(@invalid_user2, :user_modified, "/") == {:error, :invalid_recipient}
+    assert UserEmail.build_email(%Notification{to: @invalid_user2, type: :user_modified}) == {:error, :invalid_recipient}
   end
 
   test "notify user update" do
-    @valid_user
-    |> UserEmail.build_email(:user_modified, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:user_modified)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "Your profile is updated"
   end
 
   test "notify course update" do
-    @valid_user
-    |> UserEmail.build_email(:course_updated, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:course_updated)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "A course you subscribed to was updated"
   end
 
   test "notify course deleted" do
-    @valid_user
-    |> UserEmail.build_email(:course_deleted, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:course_deleted)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "A course you subscribed to was deleted"
   end
 
   test "notify term updated" do
-    @valid_user
-    |> UserEmail.build_email(:term_updated, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:term_updated)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "A term you are enrolled in was updated"
   end
 
   test "notify term deleted" do
-    @valid_user
-    |> UserEmail.build_email(:term_deleted, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:term_deleted)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "A term you are enrolled in was deleted"
   end
 
   test "notify class subscription" do
-    @valid_user
-    |> UserEmail.build_email(:class_subscribed, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:class_subscribed)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "You were subscribed to a class"
   end
 
   test "notify class updated" do
-    @valid_user
-    |> UserEmail.build_email(:class_updated, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:class_updated)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "A class you subscribe to was updated"
   end
 
   test "notify class deleted" do
-    @valid_user
-    |> UserEmail.build_email(:class_deleted, "/")
+    Notification.new()
+    |> Notification.to(@valid_user)
+    |> Notification.type(:class_deleted)
+    |> UserEmail.build_email()
     |> Mailer.deliver()
     assert_email_sent subject: "A class you subscribe to was deleted"
   end

--- a/web/controllers/class_controller.ex
+++ b/web/controllers/class_controller.ex
@@ -21,7 +21,10 @@ defmodule CoursePlanner.ClassController do
     case Repo.insert(changeset) do
       {:ok, class} ->
 
-        ClassHelper.notify_class_students(class, current_user, :class_subscribed)
+        ClassHelper.notify_class_students(class,
+          current_user,
+          :class_subscribed,
+          class_path(conn, :show, class))
 
         class
         |> Repo.preload(:students)
@@ -55,7 +58,10 @@ defmodule CoursePlanner.ClassController do
 
     case Repo.update(changeset) do
       {:ok, class} ->
-        ClassHelper.notify_class_students(class, current_user, :class_updated)
+        ClassHelper.notify_class_students(class,
+          current_user,
+          :class_updated,
+          class_path(conn, :show, class))
         conn
         |> put_flash(:info, "Class updated successfully.")
         |> redirect(to: class_path(conn, :show, class))

--- a/web/controllers/coordinator_controller.ex
+++ b/web/controllers/coordinator_controller.ex
@@ -42,7 +42,10 @@ defmodule CoursePlanner.CoordinatorController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "user" => params}) do
     case Coordinators.update(id, params) do
       {:ok, coordinator} ->
-        Users.notify_user(coordinator, current_user, :user_modified)
+        Users.notify_user(coordinator,
+          current_user,
+          :user_modified,
+          coordinator_path(conn, :show, coordinator))
         conn
         |> put_flash(:info, "Coordinator updated successfully.")
         |> redirect(to: coordinator_path(conn, :show, coordinator))

--- a/web/controllers/course_controller.ex
+++ b/web/controllers/course_controller.ex
@@ -44,7 +44,10 @@ defmodule CoursePlanner.CourseController do
 
     case Repo.update(changeset) do
       {:ok, course} ->
-        CourseHelper.notify_user_course(course, current_user, :course_updated)
+        CourseHelper.notify_user_course(course,
+          current_user,
+          :course_updated,
+          course_path(conn, :show, course))
         conn
         |> put_flash(:info, "Course updated successfully.")
         |> redirect(to: course_path(conn, :show, course))

--- a/web/controllers/student_controller.ex
+++ b/web/controllers/student_controller.ex
@@ -42,7 +42,7 @@ defmodule CoursePlanner.StudentController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "user" => params}) do
     case Students.update(id, params) do
       {:ok, student} ->
-        Users.notify_user(student, current_user, :user_modified)
+        Users.notify_user(student, current_user, :user_modified, student_path(conn, :show, student))
         conn
         |> put_flash(:info, "Student updated successfully.")
         |> redirect(to: student_path(conn, :show, student))

--- a/web/controllers/teacher_controller.ex
+++ b/web/controllers/teacher_controller.ex
@@ -42,7 +42,7 @@ defmodule CoursePlanner.TeacherController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "user" => params}) do
     case Teachers.update(id, params) do
       {:ok, teacher} ->
-        Users.notify_user(teacher, current_user, :user_modified)
+        Users.notify_user(teacher, current_user, :user_modified, teacher_path(conn, :show, teacher))
         conn
         |> put_flash(:info, "Teacher updated successfully.")
         |> redirect(to: teacher_path(conn, :show, teacher))

--- a/web/controllers/term_controller.ex
+++ b/web/controllers/term_controller.ex
@@ -49,7 +49,7 @@ defmodule CoursePlanner.TermController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "term" => term_params}) do
     case Terms.update(id, term_params) do
       {:ok, term} ->
-        Terms.notify_term_users(term, current_user, :term_updated)
+        Terms.notify_term_users(term, current_user, :term_updated, term_path(conn, :show, term))
         conn
         |> put_flash(:info, "Term updated successfully.")
         |> redirect(to: term_path(conn, :show, term))

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -31,7 +31,7 @@ defmodule CoursePlanner.UserController do
 
     case Repo.update(changeset) do
       {:ok, user} ->
-        Users.notify_user(user, current_user, :user_modified)
+        Users.notify_user(user, current_user, :user_modified, user_path(conn, :show, user))
         conn
         |> put_flash(:info, "User updated successfully.")
         |> redirect(to: user_path(conn, :show, user))

--- a/web/controllers/volunteer_controller.ex
+++ b/web/controllers/volunteer_controller.ex
@@ -42,7 +42,10 @@ defmodule CoursePlanner.VolunteerController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "user" => params}) do
     case Volunteers.update(id, params) do
       {:ok, volunteer} ->
-        Users.notify_user(volunteer, current_user, :user_modified)
+        Users.notify_user(volunteer,
+          current_user,
+          :user_modified,
+          volunteer_path(conn, :show, volunteer))
         conn
         |> put_flash(:info, "Volunteer updated successfully.")
         |> redirect(to: volunteer_path(conn, :show, volunteer))

--- a/web/models/class/class_helper.ex
+++ b/web/models/class/class_helper.ex
@@ -4,7 +4,7 @@ defmodule CoursePlanner.ClassHelper do
   """
   use CoursePlanner.Web, :model
 
-  alias CoursePlanner.{Repo, Class, Notifier, Attendance}
+  alias CoursePlanner.{Repo, Class, Notifier, Attendance, Notifier.Notification}
   alias Ecto.DateTime
   alias Ecto.Multi
 
@@ -73,7 +73,15 @@ defmodule CoursePlanner.ClassHelper do
     class
     |> get_subscribed_students()
     |> Enum.reject(fn %{id: id} -> id == current_user.id end)
-    |> Enum.each(&(Notifier.notify_user(&1, notification_type, path)))
+    |> Enum.each(&(notify_user(&1, notification_type, path)))
+  end
+
+  def notify_user(user, type, path) do
+    Notification.new()
+    |> Notification.type(type)
+    |> Notification.resource_path(path)
+    |> Notification.to(user)
+    |> Notifier.notify_user()
   end
 
   defp get_subscribed_students(class) do

--- a/web/models/class/class_helper.ex
+++ b/web/models/class/class_helper.ex
@@ -69,11 +69,11 @@ defmodule CoursePlanner.ClassHelper do
     end
   end
 
-  def notify_class_students(class, current_user, notification_type) do
+  def notify_class_students(class, current_user, notification_type, path \\ "/") do
     class
     |> get_subscribed_students()
     |> Enum.reject(fn %{id: id} -> id == current_user.id end)
-    |> Enum.each(&(Notifier.notify_user(&1, notification_type)))
+    |> Enum.each(&(Notifier.notify_user(&1, notification_type, path)))
   end
 
   defp get_subscribed_students(class) do

--- a/web/models/course/course_helper.ex
+++ b/web/models/course/course_helper.ex
@@ -28,11 +28,11 @@ defmodule CoursePlanner.CourseHelper do
     Repo.all(query)
   end
 
-  def notify_user_course(course, current_user, notification_type) do
+  def notify_user_course(course, current_user, notification_type, path \\ "/") do
     course
     |> get_subscribed_users()
     |> Enum.reject(fn %{id: id} -> id == current_user.id end)
-    |> Enum.each(&(Notifier.notify_user(&1, notification_type)))
+    |> Enum.each(&(Notifier.notify_user(&1, notification_type, path)))
   end
 
   defp get_subscribed_users(course) do

--- a/web/models/course/course_helper.ex
+++ b/web/models/course/course_helper.ex
@@ -5,7 +5,7 @@ defmodule CoursePlanner.CourseHelper do
   use CoursePlanner.Web, :model
   import Ecto.DateTime, only: [utc: 0]
 
-  alias CoursePlanner.{Repo, Course, Notifier, Coordinators}
+  alias CoursePlanner.{Repo, Course, Notifier, Coordinators, Notifier.Notification}
 
   def delete(course) do
     case course.status do
@@ -32,7 +32,15 @@ defmodule CoursePlanner.CourseHelper do
     course
     |> get_subscribed_users()
     |> Enum.reject(fn %{id: id} -> id == current_user.id end)
-    |> Enum.each(&(Notifier.notify_user(&1, notification_type, path)))
+    |> Enum.each(&(notify_user(&1, notification_type, path)))
+  end
+
+  def notify_user(user, type, path) do
+    Notification.new()
+    |> Notification.type(type)
+    |> Notification.resource_path(path)
+    |> Notification.to(user)
+    |> Notifier.notify_user()
   end
 
   defp get_subscribed_users(course) do

--- a/web/models/terms.ex
+++ b/web/models/terms.ex
@@ -71,11 +71,11 @@ defmodule CoursePlanner.Terms do
     from t in Term, where: is_nil(t.deleted_at)
   end
 
-  def notify_term_users(term, current_user, notification_type) do
+  def notify_term_users(term, current_user, notification_type, path \\ "/") do
     term
     |> get_subscribed_users()
     |> Enum.reject(fn %{id: id} -> id == current_user.id end)
-    |> Enum.each(&(Notifier.notify_user(&1, notification_type)))
+    |> Enum.each(&(Notifier.notify_user(&1, notification_type, path)))
   end
 
   defp get_subscribed_users(term) do

--- a/web/models/terms.ex
+++ b/web/models/terms.ex
@@ -2,7 +2,7 @@ defmodule CoursePlanner.Terms do
   @moduledoc """
     Handle all interactions with Terms, create, list, fetch, edit, and delete
   """
-  alias CoursePlanner.{Repo, OfferedCourse, Notifier, Coordinators, Notifier.Notification}
+  alias CoursePlanner.{Repo, Notifier, Coordinators, Notifier.Notification}
   alias CoursePlanner.Terms.Term
   alias Ecto.{Changeset, DateTime}
   import Ecto.Query, only: [from: 2]

--- a/web/models/terms.ex
+++ b/web/models/terms.ex
@@ -2,7 +2,7 @@ defmodule CoursePlanner.Terms do
   @moduledoc """
     Handle all interactions with Terms, create, list, fetch, edit, and delete
   """
-  alias CoursePlanner.{Repo, OfferedCourse, Notifier, Coordinators}
+  alias CoursePlanner.{Repo, OfferedCourse, Notifier, Coordinators, Notifier.Notification}
   alias CoursePlanner.Terms.Term
   alias Ecto.{Changeset, DateTime}
   import Ecto.Query, only: [from: 2]
@@ -75,7 +75,15 @@ defmodule CoursePlanner.Terms do
     term
     |> get_subscribed_users()
     |> Enum.reject(fn %{id: id} -> id == current_user.id end)
-    |> Enum.each(&(Notifier.notify_user(&1, notification_type, path)))
+    |> Enum.each(&(notify_user(&1, notification_type, path)))
+  end
+
+  def notify_user(user, type, path) do
+    Notification.new()
+    |> Notification.type(type)
+    |> Notification.resource_path(path)
+    |> Notification.to(user)
+    |> Notifier.notify_user()
   end
 
   defp get_subscribed_users(term) do

--- a/web/templates/email/class_updated.html.eex
+++ b/web/templates/email/class_updated.html.eex
@@ -1,3 +1,4 @@
 <div>
   <h2><%= @name%>, a class you subscribe to was updated.</h2>
+  <h3>Check the updated class <%= link "here: ", to: @path%></h3>
 </div>

--- a/web/templates/email/course_updated.html.eex
+++ b/web/templates/email/course_updated.html.eex
@@ -1,3 +1,4 @@
 <div>
   <h2><%= @name%>, a course you subscribed to was updated.</h2>
+  <h3>Check the updated course <%= link "here: ", to: @path%></h3>
 </div>

--- a/web/templates/email/term_updated.html.eex
+++ b/web/templates/email/term_updated.html.eex
@@ -1,3 +1,4 @@
 <div>
   <h2><%= @name%>, a term you are enrolled in was updated.</h2>
+  <h3>Check the updated term <%= link "here: ", to: @path%></h3>
 </div>

--- a/web/templates/email/user_updated.html.eex
+++ b/web/templates/email/user_updated.html.eex
@@ -1,3 +1,4 @@
 <div>
   <h2><%= @name%>, your profile is updated.</h2>
+  <h3>Check your profile <%= link "here: ", to: @path%></h3>
 </div>


### PR DESCRIPTION
To build the resource link in the template, we would need `Plug.Conn` passed around which I thought it was bad idea, so I'm sending the path through a parameter.
It might be getting a little bit clunky with too many parameters, but I couldn't think of a better way, so please take a look @ggpasqualino @ghatighorias if you have a better idea.