### PR TITLE
Remove course manipulation from term scope

### DIFF
--- a/test/controllers/term_controller_test.exs
+++ b/test/controllers/term_controller_test.exs
@@ -2,7 +2,7 @@ defmodule CoursePlanner.TermControllerTest do
   use CoursePlanner.ConnCase
 
   alias CoursePlanner.Terms.Term
-  alias CoursePlanner.{Course, OfferedCourse , User}
+  alias CoursePlanner.User
 
   setup do
     user =
@@ -35,21 +35,6 @@ defmodule CoursePlanner.TermControllerTest do
     conn = post conn, term_path(conn, :create), term: valid_attrs
     assert redirected_to(conn) == term_path(conn, :index)
     assert Repo.get_by(Term, valid_attrs)
-  end
-
-  test "creates term with course and redirects when data is valid", %{conn: conn} do
-    course = create_course("Course")
-    valid_attrs =
-      %{
-        name: "Spring",
-        start_date: %{day: 01, month: 01, year: 2010},
-        end_date: %{day: 01, month: 06, year: 2010},
-        status: "Planned",
-        course_ids: ["#{course.id}"]
-      }
-    conn = post conn, term_path(conn, :create), term: valid_attrs
-    assert redirected_to(conn) == term_path(conn, :index)
-    assert %{courses: [%{name: "Course"}]} = (Term |> Repo.get_by(name: "Spring") |> Repo.preload(:courses))
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
@@ -110,20 +95,6 @@ defmodule CoursePlanner.TermControllerTest do
     assert Repo.get_by(Term, name: "Spring")
   end
 
-  test "updates term with course and redirects when data is valid", %{conn: conn} do
-    course1 = create_course("Course1")
-    term = create_term()
-    Repo.insert!(%OfferedCourse{term_id: term.id, course_id: course1.id})
-
-    assert %{courses: [%{name: "Course1"}]} = (Term |> Repo.get(term.id) |> Repo.preload(:courses))
-
-    course2 = create_course("Course2")
-    conn = put conn, term_path(conn, :update, term), term: %{course_ids: ["#{course2.id}"]}
-
-    assert redirected_to(conn) == term_path(conn, :show, term)
-    assert %{courses: [%{name: "Course2"}]} = (Term |> Repo.get(term.id) |> Repo.preload(:courses))
-  end
-
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     term = create_term()
     conn = put conn, term_path(conn, :update, term), term: %{name: ""}
@@ -148,18 +119,5 @@ defmodule CoursePlanner.TermControllerTest do
         end_date: %Ecto.Date{day: 1, month: 6, year: 2017},
         status: "Planned"
       })
-  end
-
-  defp create_course(name) do
-    Repo.insert!(
-      Course.changeset(
-        %Course{},
-        %{
-          name: name,
-          description: "Description",
-          number_of_sessions: 1,
-          session_duration: "01:00:00",
-          status: "Active"
-        }))
   end
 end

--- a/web/models/offered_course.ex
+++ b/web/models/offered_course.ex
@@ -30,12 +30,4 @@ defmodule CoursePlanner.OfferedCourse do
     |> assoc_constraint(:term)
     |> assoc_constraint(:course)
   end
-
-  def add_to_term_changeset(course_id) do
-    %__MODULE__{}
-    |> cast(%{"course_id" => course_id}, [:course_id])
-    |> validate_required([:course_id])
-    |> assoc_constraint(:term)
-    |> assoc_constraint(:course)
-  end
 end

--- a/web/models/terms.ex
+++ b/web/models/terms.ex
@@ -24,6 +24,7 @@ defmodule CoursePlanner.Terms do
   def get(id) do
     non_deleted_query()
     |> Repo.get(id)
+    |> Repo.preload([:courses])
   end
 
   def edit(id) do

--- a/web/models/terms.ex
+++ b/web/models/terms.ex
@@ -2,7 +2,7 @@ defmodule CoursePlanner.Terms do
   @moduledoc """
     Handle all interactions with Terms, create, list, fetch, edit, and delete
   """
-  alias CoursePlanner.{Repo, OfferedCourse, Notifier, Coordinators}
+  alias CoursePlanner.{Repo, Notifier, Coordinators}
   alias CoursePlanner.Terms.Term
   alias Ecto.{Changeset, DateTime}
   import Ecto.Query, only: [from: 2]
@@ -18,19 +18,12 @@ defmodule CoursePlanner.Terms do
   def create(params) do
     %Term{}
     |> Term.changeset(params)
-    |> Changeset.put_assoc(:offered_courses, course_changesets(params))
     |> Repo.insert
   end
-
-  def course_changesets(%{"course_ids" => ids}) do
-    Enum.map(ids, &OfferedCourse.add_to_term_changeset/1)
-  end
-  def course_changesets(_), do: []
 
   def get(id) do
     non_deleted_query()
     |> Repo.get(id)
-    |> Repo.preload(:courses)
   end
 
   def edit(id) do
@@ -47,7 +40,6 @@ defmodule CoursePlanner.Terms do
         params = Map.put_new(params, "holidays", [])
         term
         |> Term.changeset(params)
-        |> Changeset.put_assoc(:offered_courses, course_changesets(params))
         |> Repo.update
         |> format_update_error(term)
     end

--- a/web/templates/term/form.html.eex
+++ b/web/templates/term/form.html.eex
@@ -39,12 +39,6 @@
   </div>
 
   <div class="form-group">
-    <%= label f, :course_ids, class: "control-label" %>
-    <%= multiple_select f, :course_ids, courses_to_select(), selected: selected_courses(@changeset), class: "form-control" %>
-    <%= error_tag f, :status %>
-  </div>
-
-  <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/web/templates/term/show.html.eex
+++ b/web/templates/term/show.html.eex
@@ -37,6 +37,20 @@
       <% end %>
     </table>
   <% end %>
+
+  <%= if length(@term.courses) > 0 do %>
+    <strong>Courses</strong>
+    <table>
+      <tr>
+        <th>Name</th>
+      </tr>
+      <%= for t <- @term.courses do %>
+        <tr>
+          <td><%= t.name %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
 </ul>
 
 <%= link "Edit", to: term_path(@conn, :edit, @term) %>

--- a/web/templates/term/show.html.eex
+++ b/web/templates/term/show.html.eex
@@ -37,20 +37,6 @@
       <% end %>
     </table>
   <% end %>
-
-  <%= if length(@term.courses) > 0 do %>
-    <strong>Courses</strong>
-    <table>
-      <tr>
-        <th>Name</th>
-      </tr>
-      <%= for t <- @term.courses do %>
-        <tr>
-          <td><%= t.name %></td>
-        </tr>
-      <% end %>
-    </table>
-  <% end %>
 </ul>
 
 <%= link "Edit", to: term_path(@conn, :edit, @term) %>

--- a/web/views/term_view.ex
+++ b/web/views/term_view.ex
@@ -2,8 +2,6 @@ defmodule CoursePlanner.TermView do
   use CoursePlanner.Web, :view
 
   alias CoursePlanner.Terms.{Term, Holiday}
-  alias CoursePlanner.CourseHelper
-  alias Ecto.Changeset
   alias Phoenix.HTML.{Form, FormData}
 
   def link_to_holiday_fields(form, field) do
@@ -46,16 +44,5 @@ defmodule CoursePlanner.TermView do
   defp container_id(form, field) do
     id = Form.input_id(form, field)
     id <> "_nested_form"
-  end
-
-  def courses_to_select do
-    CourseHelper.all_none_deleted()
-    |> Enum.map(&({&1.name, &1.id}))
-  end
-
-  def selected_courses(changeset) do
-    changeset
-    |> Changeset.get_field(:courses)
-    |> Enum.map(&(&1.id))
   end
 end


### PR DESCRIPTION
Remove course manipulation from terms as we discussed since `OfferedCourse` already provides the needed functionality.