### PR TITLE
Halt connection on forbidden

### DIFF
--- a/web/helper.ex
+++ b/web/helper.ex
@@ -9,6 +9,7 @@ defmodule CoursePlanner.Helper do
     conn
     |> put_status(403)
     |> render(CoursePlanner.ErrorView, "403.html")
+    |> halt()
   end
 
 end


### PR DESCRIPTION
Before if we didn't halt the connection we would raise an exception
`Plug.Conn.AlreadySentError`