### PR TITLE
Fixes Error in show attendance when no student or teacher for class

### DIFF
--- a/web/controllers/attendance_controller.ex
+++ b/web/controllers/attendance_controller.ex
@@ -33,9 +33,9 @@ defmodule CoursePlanner.AttendanceController do
     end
   end
 
-  def show(%{assigns: %{current_user: %{id: _id, role: "Teacher"}}} = conn,
+  def show(%{assigns: %{current_user: %{id: id, role: "Teacher"}}} = conn,
            %{"id" => offered_course_id}) do
-    case AttendanceHelper.get_course_attendances(offered_course_id) do
+    case AttendanceHelper.get_teacher_course_attendances(offered_course_id, id) do
       nil ->
         conn
         |> put_status(404)

--- a/web/controllers/attendance_controller.ex
+++ b/web/controllers/attendance_controller.ex
@@ -23,25 +23,42 @@ defmodule CoursePlanner.AttendanceController do
 
   def show(%{assigns: %{current_user: %{id: _id, role: "Coordinator"}}} = conn,
            %{"id" => offered_course_id}) do
-    offered_course = AttendanceHelper.get_course_attendances(offered_course_id)
-    render(conn, "show_coordinator.html", offered_course: offered_course)
+    case AttendanceHelper.get_course_attendances(offered_course_id) do
+      nil ->
+        conn
+        |> put_status(404)
+        |> render(CoursePlanner.ErrorView, "404.html")
+      offered_course ->
+        render(conn, "show_coordinator.html", offered_course: offered_course)
+    end
   end
 
   def show(%{assigns: %{current_user: %{id: _id, role: "Teacher"}}} = conn,
            %{"id" => offered_course_id}) do
-    offered_course = AttendanceHelper.get_course_attendances(offered_course_id)
-    render(conn, "show_teacher.html", offered_course: offered_course)
+    case AttendanceHelper.get_course_attendances(offered_course_id) do
+      nil ->
+        conn
+        |> put_status(404)
+        |> render(CoursePlanner.ErrorView, "404.html")
+      offered_course ->
+        render(conn, "show_teacher.html", offered_course: offered_course)
+    end
   end
 
   def show(%{assigns: %{current_user: %{id: id, role: "Student"}}} = conn,
            %{"id" => offered_course_id}) do
     offered_course =
-     OfferedCourse
-     |> Repo.get!(offered_course_id)
-     |> Repo.preload([:term, :course, :teachers])
+    OfferedCourse
+    |> Repo.get(offered_course_id)
+    |> Repo.preload([:term, :course, :teachers])
 
-    attendances = AttendanceHelper.get_student_attendances(offered_course_id, id)
-
-    render(conn, "show_student.html", attendances: attendances, offered_course: offered_course)
+    case AttendanceHelper.get_student_attendances(offered_course_id, id) do
+     [] ->
+       conn
+       |> put_status(404)
+       |> render(CoursePlanner.ErrorView, "404.html")
+     attendances ->
+       render(conn, "show_student.html", attendances: attendances, offered_course: offered_course)
+    end
   end
 end

--- a/web/models/attendance/attendance_helper.ex
+++ b/web/models/attendance/attendance_helper.ex
@@ -30,14 +30,17 @@ defmodule CoursePlanner.AttendanceHelper do
   def get_all_offered_courses do
     Repo.all(from oc in OfferedCourse,
       join: c in assoc(oc, :classes),
-      preload: [:term, :course, :teachers, classes: c])
+      join: s in assoc(oc, :students),
+      join: t in assoc(oc, :teachers),
+      preload: [:term, :course, teachers: t, students: s, classes: c])
   end
 
   def get_all_teacher_offered_courses(teacher_id) do
     Repo.all(from oc in OfferedCourse,
       join: t in assoc(oc, :teachers),
       join: c in assoc(oc, :classes),
-      preload: [:term, :course, teachers: t, classes: c],
+      join: s in assoc(oc, :students),
+      preload: [:term, :course, teachers: t, students: s, classes: c],
       where: t.id == ^teacher_id)
   end
 
@@ -45,7 +48,8 @@ defmodule CoursePlanner.AttendanceHelper do
     Repo.all(from oc in OfferedCourse,
       join: s in assoc(oc, :students),
       join: c in assoc(oc, :classes),
-      preload: [:term, :course, :teachers, students: s, classes: c],
+      join: t in assoc(oc, :teachers),
+      preload: [:term, :course, teachers: t, students: s, classes: c],
       where: s.id == ^student_id)
   end
 end

--- a/web/models/attendance/attendance_helper.ex
+++ b/web/models/attendance/attendance_helper.ex
@@ -17,6 +17,18 @@ defmodule CoursePlanner.AttendanceHelper do
       order_by: [asc: c.date])
   end
 
+  def get_teacher_course_attendances(offered_course_id, teacher_id) do
+    Repo.one(from oc in OfferedCourse,
+      join: t in assoc(oc, :teachers),
+      join: s in assoc(oc, :students),
+      join: c in assoc(oc, :classes),
+      join: a in assoc(c,  :attendances),
+      preload: [:term, :course, teachers: t, students: s],
+      preload: [classes: {c, attendances: a}],
+      where: oc.id == ^offered_course_id and is_nil(s.deleted_at) and t.id == ^teacher_id,
+      order_by: [asc: c.date])
+  end
+
   def get_student_attendances(offered_course_id, student_id) do
     Repo.all(from a in Attendance,
       join: s in assoc(a, :student),


### PR DESCRIPTION
* preloads the teacher and students and does not show them in index if there none attached to offered_course
* fixes controller if query fails to find all data for display ( students and teachers and attendances of a class) then show return 404

[related nostromo card](https://app.nostromo.io/work/course-planner/internal-server-error-showing-an-attendance?e21vZHVsZTp3b3JrLHByb2plY3Q6NjM2OCxjYXJkOjkxMDIwLGNhcmRfdGl0bGU6aW50ZXJuYWwtc2VydmVyLWVycm9yLXNob3dpbmctYW4tYXR0ZW5kYW5jZX0=)