### PR TITLE
Replace resource path by url

### DIFF
--- a/web/controllers/class_controller.ex
+++ b/web/controllers/class_controller.ex
@@ -24,7 +24,7 @@ defmodule CoursePlanner.ClassController do
         ClassHelper.notify_class_students(class,
           current_user,
           :class_subscribed,
-          class_path(conn, :show, class))
+          class_url(conn, :show, class))
 
         class
         |> Repo.preload(:students)
@@ -61,7 +61,7 @@ defmodule CoursePlanner.ClassController do
         ClassHelper.notify_class_students(class,
           current_user,
           :class_updated,
-          class_path(conn, :show, class))
+          class_url(conn, :show, class))
         conn
         |> put_flash(:info, "Class updated successfully.")
         |> redirect(to: class_path(conn, :show, class))

--- a/web/controllers/coordinator_controller.ex
+++ b/web/controllers/coordinator_controller.ex
@@ -45,7 +45,7 @@ defmodule CoursePlanner.CoordinatorController do
         Users.notify_user(coordinator,
           current_user,
           :user_modified,
-          coordinator_path(conn, :show, coordinator))
+          coordinator_url(conn, :show, coordinator))
         conn
         |> put_flash(:info, "Coordinator updated successfully.")
         |> redirect(to: coordinator_path(conn, :show, coordinator))

--- a/web/controllers/course_controller.ex
+++ b/web/controllers/course_controller.ex
@@ -47,7 +47,7 @@ defmodule CoursePlanner.CourseController do
         CourseHelper.notify_user_course(course,
           current_user,
           :course_updated,
-          course_path(conn, :show, course))
+          course_url(conn, :show, course))
         conn
         |> put_flash(:info, "Course updated successfully.")
         |> redirect(to: course_path(conn, :show, course))

--- a/web/controllers/student_controller.ex
+++ b/web/controllers/student_controller.ex
@@ -42,7 +42,7 @@ defmodule CoursePlanner.StudentController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "user" => params}) do
     case Students.update(id, params) do
       {:ok, student} ->
-        Users.notify_user(student, current_user, :user_modified, student_path(conn, :show, student))
+        Users.notify_user(student, current_user, :user_modified, student_url(conn, :show, student))
         conn
         |> put_flash(:info, "Student updated successfully.")
         |> redirect(to: student_path(conn, :show, student))

--- a/web/controllers/teacher_controller.ex
+++ b/web/controllers/teacher_controller.ex
@@ -42,7 +42,7 @@ defmodule CoursePlanner.TeacherController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "user" => params}) do
     case Teachers.update(id, params) do
       {:ok, teacher} ->
-        Users.notify_user(teacher, current_user, :user_modified, teacher_path(conn, :show, teacher))
+        Users.notify_user(teacher, current_user, :user_modified, teacher_url(conn, :show, teacher))
         conn
         |> put_flash(:info, "Teacher updated successfully.")
         |> redirect(to: teacher_path(conn, :show, teacher))

--- a/web/controllers/term_controller.ex
+++ b/web/controllers/term_controller.ex
@@ -52,7 +52,7 @@ defmodule CoursePlanner.TermController do
   def update(%{assigns: %{current_user: current_user}} = conn, %{"id" => id, "term" => term_params}) do
     case Terms.update(id, term_params) do
       {:ok, term} ->
-        Terms.notify_term_users(term, current_user, :term_updated, term_path(conn, :show, term))
+        Terms.notify_term_users(term, current_user, :term_updated, term_url(conn, :show, term))
         conn
         |> put_flash(:info, "Term updated successfully.")
         |> redirect(to: term_path(conn, :show, term))

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -31,7 +31,7 @@ defmodule CoursePlanner.UserController do
 
     case Repo.update(changeset) do
       {:ok, user} ->
-        Users.notify_user(user, current_user, :user_modified, user_path(conn, :show, user))
+        Users.notify_user(user, current_user, :user_modified, user_url(conn, :show, user))
         conn
         |> put_flash(:info, "User updated successfully.")
         |> redirect(to: user_path(conn, :show, user))

--- a/web/controllers/volunteer_controller.ex
+++ b/web/controllers/volunteer_controller.ex
@@ -45,7 +45,7 @@ defmodule CoursePlanner.VolunteerController do
         Users.notify_user(volunteer,
           current_user,
           :user_modified,
-          volunteer_path(conn, :show, volunteer))
+          volunteer_url(conn, :show, volunteer))
         conn
         |> put_flash(:info, "Volunteer updated successfully.")
         |> redirect(to: volunteer_path(conn, :show, volunteer))


### PR DESCRIPTION
Before we were sending notifications with broken links because they had
only the path of the resource instead of the full url.