### PR TITLE
Restrict user permission to user controllers.

### DIFF
--- a/lib/course_planner/permissions.ex
+++ b/lib/course_planner/permissions.ex
@@ -13,6 +13,13 @@ defimpl Canada.Can, for: CoursePlanner.User do
   def can?(%User{role: role}, _action, %Course{})
     when role in ["Teacher", "Student", "Volunteer"], do: false
 
+  def can?(%User{id: id}, action, %User{id: id})
+    when action in [:show, :edit, :update], do: true
+  def can?(%User{role: role}, _action, User)
+    when role in ["Teacher", "Student", "Volunteer"], do: false
+  def can?(%User{role: role}, _action, %User{})
+    when role in ["Teacher", "Student", "Volunteer"], do: false
+
   def can?(%User{role: "Volunteer", id: id}, :show, %Task{user_id: id}), do: true
   def can?(%User{role: "Volunteer"}, :index, Task), do: true
   def can?(%User{role: "Volunteer"}, :grab, %Task{user_id: nil}), do: true

--- a/test/controllers/coordinator_controller_test.exs
+++ b/test/controllers/coordinator_controller_test.exs
@@ -4,19 +4,20 @@ defmodule CoursePlanner.CoordinatorControllerTest do
   alias CoursePlanner.User
   alias CoursePlanner.Coordinators
 
+  import CoursePlanner.Factory
+
   @valid_attrs %{name: "some content", email: "valid@email"}
   @invalid_attrs %{}
-  @user %User{
-    name: "Test User",
-    email: "testuser@example.com",
-    password: "secret",
-    password_confirmation: "secret"}
 
   setup do
-    conn =
-      Phoenix.ConnTest.build_conn()
-        |> assign(:current_user, @user)
-    {:ok, conn: conn}
+    {:ok, conn: login_as(:coordinator)}
+  end
+
+  defp login_as(user_type) do
+    user = insert(user_type)
+
+    Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, user)
   end
 
   test "lists all entries on index", %{conn: conn} do
@@ -65,5 +66,120 @@ defmodule CoursePlanner.CoordinatorControllerTest do
   test "renders form for new resources", %{conn: conn} do
     conn = get conn, coordinator_path(conn, :new)
     assert html_response(conn, 200) =~ "New coordinator"
+  end
+
+  test "does not shows chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    coordinator = insert(:coordinator)
+
+    conn = get student_conn, coordinator_path(student_conn, :show, coordinator)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, coordinator_path(teacher_conn, :show, coordinator)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, coordinator_path(volunteer_conn, :show, coordinator)
+    assert html_response(conn, 403)
+  end
+
+  test "does not list entries on index for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    conn = get student_conn, coordinator_path(student_conn, :index)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, coordinator_path(teacher_conn, :index)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, coordinator_path(volunteer_conn, :index)
+    assert html_response(conn, 403)
+  end
+
+  test "does not renders form for editing chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    coordinator = insert(:coordinator)
+
+    conn = get student_conn, coordinator_path(student_conn, :edit, coordinator)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, coordinator_path(teacher_conn, :edit, coordinator)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, coordinator_path(volunteer_conn, :edit, coordinator)
+    assert html_response(conn, 403)
+  end
+
+  test "does not delete a chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    coordinator = insert(:coordinator)
+
+    conn = delete student_conn, coordinator_path(student_conn, :delete, coordinator.id)
+    assert html_response(conn, 403)
+
+    conn = delete teacher_conn, coordinator_path(teacher_conn, :delete, coordinator.id)
+    assert html_response(conn, 403)
+
+    conn = delete volunteer_conn, coordinator_path(volunteer_conn, :delete, coordinator.id)
+    assert html_response(conn, 403)
+  end
+
+  test "does not render form for new class for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    conn = get student_conn, coordinator_path(student_conn, :new)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, coordinator_path(teacher_conn, :new)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, coordinator_path(volunteer_conn, :new)
+    assert html_response(conn, 403)
+  end
+
+  test "does not create class for non coordinator use", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    coordinator = insert(:coordinator)
+
+    conn = post student_conn, coordinator_path(student_conn, :create), class: coordinator
+    assert html_response(conn, 403)
+
+    conn = post teacher_conn, coordinator_path(teacher_conn, :create), class: coordinator
+    assert html_response(conn, 403)
+
+    conn = post volunteer_conn, coordinator_path(volunteer_conn, :create), class: coordinator
+    assert html_response(conn, 403)
+  end
+
+  test "does not update chosen coordinator for non coordinator use", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    coordinator = Repo.insert! %User{}
+
+    conn = put student_conn, coordinator_path(student_conn, :update, coordinator), coordinator: @valid_attrs
+    assert html_response(conn, 403)
+
+    conn = put teacher_conn, coordinator_path(teacher_conn, :update, coordinator), coordinator: @valid_attrs
+    assert html_response(conn, 403)
+
+    conn = put volunteer_conn, coordinator_path(volunteer_conn, :update, coordinator), coordinator: @valid_attrs
+    assert html_response(conn, 403)
   end
 end

--- a/test/controllers/teacher_controller_test.exs
+++ b/test/controllers/teacher_controller_test.exs
@@ -2,20 +2,20 @@ defmodule CoursePlanner.TeacherControllerTest do
   use CoursePlanner.ConnCase
 
   alias CoursePlanner.{Repo, User, Teachers}
+  import CoursePlanner.Factory
 
   @valid_attrs %{name: "some content", email: "valid@email"}
   @invalid_attrs %{}
-  @user %User{
-    name: "Test User",
-    email: "testuser@example.com",
-    password: "secret",
-    password_confirmation: "secret"}
 
   setup do
-    conn =
-      Phoenix.ConnTest.build_conn()
-        |> assign(:current_user, @user)
-    {:ok, conn: conn}
+    {:ok, conn: login_as(:coordinator)}
+  end
+
+  defp login_as(user_type) do
+    user = insert(user_type)
+
+    Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, user)
   end
 
   test "lists all entries on index", %{conn: conn} do
@@ -65,4 +65,148 @@ defmodule CoursePlanner.TeacherControllerTest do
     conn = get conn, teacher_path(conn, :new)
     assert html_response(conn, 200) =~ "New teacher"
   end
+
+  test "does not shows chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    teacher = insert(:teacher)
+
+    conn = get student_conn, teacher_path(student_conn, :show, teacher)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, teacher_path(teacher_conn, :show, teacher)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, teacher_path(volunteer_conn, :show, teacher)
+    assert html_response(conn, 403)
+  end
+
+  test "does not list entries on index for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    conn = get student_conn, teacher_path(student_conn, :index)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, teacher_path(teacher_conn, :index)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, teacher_path(volunteer_conn, :index)
+    assert html_response(conn, 403)
+  end
+
+  test "does not renders form for editing chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    teacher = insert(:teacher)
+
+    conn = get student_conn, teacher_path(student_conn, :edit, teacher)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, teacher_path(teacher_conn, :edit, teacher)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, teacher_path(volunteer_conn, :edit, teacher)
+    assert html_response(conn, 403)
+  end
+
+  test "does not delete a chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    teacher = insert(:teacher)
+
+    conn = delete student_conn, teacher_path(student_conn, :delete, teacher.id)
+    assert html_response(conn, 403)
+
+    conn = delete teacher_conn, teacher_path(teacher_conn, :delete, teacher.id)
+    assert html_response(conn, 403)
+
+    conn = delete volunteer_conn, teacher_path(volunteer_conn, :delete, teacher.id)
+    assert html_response(conn, 403)
+  end
+
+  test "does not render form for new class for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    conn = get student_conn, teacher_path(student_conn, :new)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, teacher_path(teacher_conn, :new)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, teacher_path(volunteer_conn, :new)
+    assert html_response(conn, 403)
+  end
+
+  test "does not create class for non coordinator use", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    teacher = insert(:teacher)
+
+    conn = post student_conn, teacher_path(student_conn, :create), class: teacher
+    assert html_response(conn, 403)
+
+    conn = post teacher_conn, teacher_path(teacher_conn, :create), class: teacher
+    assert html_response(conn, 403)
+
+    conn = post volunteer_conn, teacher_path(volunteer_conn, :create), class: teacher
+    assert html_response(conn, 403)
+  end
+
+  test "does not update chosen teacher for non coordinator use", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    teacher = Repo.insert! %User{}
+
+    conn = put student_conn, teacher_path(student_conn, :update, teacher), teacher: @valid_attrs
+    assert html_response(conn, 403)
+
+    conn = put teacher_conn, teacher_path(teacher_conn, :update, teacher), teacher: @valid_attrs
+    assert html_response(conn, 403)
+
+    conn = put volunteer_conn, teacher_path(volunteer_conn, :update, teacher), teacher: @valid_attrs
+    assert html_response(conn, 403)
+  end
+
+  test "show the teacher himself" do
+    teacher = insert(:teacher)
+    teacher_conn = Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, teacher)
+
+    conn = get teacher_conn, teacher_path(teacher_conn, :show, teacher)
+    assert html_response(conn, 200) =~ "Show teacher"
+  end
+
+  test "edit the teacher himself" do
+    teacher = insert(:teacher)
+    teacher_conn = Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, teacher)
+
+    conn = get teacher_conn, teacher_path(teacher_conn, :edit, teacher)
+    assert html_response(conn, 200) =~ "Edit teacher"
+  end
+
+  test "update the teacher himself" do
+    teacher = insert(:teacher)
+    teacher_conn = Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, teacher)
+
+    conn = put teacher_conn, teacher_path(teacher_conn, :update, teacher), user: @valid_attrs
+    assert redirected_to(conn) == teacher_path(conn, :show, teacher)
+    assert Repo.get_by(User, @valid_attrs)
+  end
+
 end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -3,18 +3,20 @@ defmodule CoursePlanner.UserControllerTest do
   alias CoursePlanner.Repo
   alias CoursePlanner.User
 
+  import CoursePlanner.Factory
+
+  @valid_attrs %{name: "some content", email: "valid@email"}
   @invalid_attrs %{}
-  @user %User{
-    name: "Test User",
-    email: "testuser@example.com",
-    password: "secret",
-    password_confirmation: "secret"}
 
   setup do
-    conn =
-      Phoenix.ConnTest.build_conn()
-        |> assign(:current_user, @user)
-    {:ok, conn: conn}
+    {:ok, conn: login_as(:coordinator)}
+  end
+
+  defp login_as(user_type) do
+    user = insert(user_type)
+
+    Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, user)
   end
 
   test "lists all entries on index", %{conn: conn} do
@@ -44,4 +46,116 @@ defmodule CoursePlanner.UserControllerTest do
     conn = put conn, user_path(conn, :update, user), user: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit user"
   end
+
+  test "does not shows chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    user = insert(:student)
+
+    conn = get student_conn, user_path(student_conn, :show, user)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, user_path(teacher_conn, :show, user)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, user_path(volunteer_conn, :show, user)
+    assert html_response(conn, 403)
+  end
+
+  test "does not list entries on index for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    conn = get student_conn, user_path(student_conn, :index)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, user_path(teacher_conn, :index)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, user_path(volunteer_conn, :index)
+    assert html_response(conn, 403)
+  end
+
+  test "does not renders form for editing chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    user = insert(:student)
+
+    conn = get student_conn, user_path(student_conn, :edit, user)
+    assert html_response(conn, 403)
+
+    conn = get teacher_conn, user_path(teacher_conn, :edit, user)
+    assert html_response(conn, 403)
+
+    conn = get volunteer_conn, user_path(volunteer_conn, :edit, user)
+    assert html_response(conn, 403)
+  end
+
+  test "does not delete a chosen resource for non coordinator user", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    user = insert(:student)
+
+    conn = delete student_conn, user_path(student_conn, :delete, user.id)
+    assert html_response(conn, 403)
+
+    conn = delete teacher_conn, user_path(teacher_conn, :delete, user.id)
+    assert html_response(conn, 403)
+
+    conn = delete volunteer_conn, user_path(volunteer_conn, :delete, user.id)
+    assert html_response(conn, 403)
+  end
+
+  test "does not update chosen user for non coordinator use", %{conn: _conn} do
+    student_conn   = login_as(:student)
+    teacher_conn   = login_as(:teacher)
+    volunteer_conn = login_as(:volunteer)
+
+    user = Repo.insert! %User{}
+
+    conn = put student_conn, user_path(student_conn, :update, user), user: @valid_attrs
+    assert html_response(conn, 403)
+
+    conn = put teacher_conn, user_path(teacher_conn, :update, user), user: @valid_attrs
+    assert html_response(conn, 403)
+
+    conn = put volunteer_conn, user_path(volunteer_conn, :update, user), user: @valid_attrs
+    assert html_response(conn, 403)
+  end
+
+  test "show the user himself" do
+    user = insert(:user)
+    user_conn = Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, user)
+
+    conn = get user_conn, user_path(user_conn, :show, user)
+    assert html_response(conn, 200) =~ "Show user"
+  end
+
+  test "edit the user himself" do
+    user = insert(:user)
+    user_conn = Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, user)
+
+    conn = get user_conn, user_path(user_conn, :edit, user)
+    assert html_response(conn, 200) =~ "Edit user"
+  end
+
+  test "update the user himself" do
+    user = insert(:user)
+    user_conn = Phoenix.ConnTest.build_conn()
+    |> assign(:current_user, user)
+
+    conn = put user_conn, user_path(user_conn, :update, user), user: @valid_attrs
+    assert redirected_to(conn) == user_path(conn, :show, user)
+    assert Repo.get_by(User, @valid_attrs)
+  end
+
 end

--- a/web/controllers/coordinator_controller.ex
+++ b/web/controllers/coordinator_controller.ex
@@ -3,6 +3,9 @@ defmodule CoursePlanner.CoordinatorController do
   alias CoursePlanner.{User, Coordinators, Router.Helpers, Users}
   alias Coherence.ControllerHelpers
 
+  import Canary.Plugs
+  plug :authorize_resource, model: User
+
   def index(conn, _params) do
     render(conn, "index.html", coordinators: Coordinators.all())
   end

--- a/web/controllers/student_controller.ex
+++ b/web/controllers/student_controller.ex
@@ -3,6 +3,9 @@ defmodule CoursePlanner.StudentController do
   alias CoursePlanner.{User, Students, Router.Helpers, Users}
   alias Coherence.ControllerHelpers
 
+  import Canary.Plugs
+  plug :authorize_resource, model: User
+
   def index(conn, _params) do
     render(conn, "index.html", students: Students.all())
   end

--- a/web/controllers/teacher_controller.ex
+++ b/web/controllers/teacher_controller.ex
@@ -3,6 +3,9 @@ defmodule CoursePlanner.TeacherController do
   alias CoursePlanner.{User, Teachers, Router.Helpers, Users}
   alias Coherence.ControllerHelpers
 
+  import Canary.Plugs
+  plug :authorize_resource, model: User
+
   def index(conn, _params) do
     render(conn, "index.html", teachers: Teachers.all())
   end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -3,6 +3,9 @@ defmodule CoursePlanner.UserController do
   alias CoursePlanner.{User, Users}
   require Logger
 
+  import Canary.Plugs
+  plug :authorize_resource, model: User
+
   def index(conn, _params) do
     query = from u in User, where: is_nil(u.deleted_at)
     users = Repo.all(query)

--- a/web/controllers/volunteer_controller.ex
+++ b/web/controllers/volunteer_controller.ex
@@ -3,6 +3,9 @@ defmodule CoursePlanner.VolunteerController do
   alias CoursePlanner.{User, Volunteers, Router.Helpers, Users}
   alias Coherence.ControllerHelpers
 
+  import Canary.Plugs
+  plug :authorize_resource, model: User
+
   def index(conn, _params) do
     render(conn, "index.html", volunteers: Volunteers.all())
   end


### PR DESCRIPTION
Restrict user access to `{student, teacher, coordinator, volunteer and user}_controller`s apart from showing, editing and updating himself.