### PR TITLE
Change user name and email on coherence mailer

### DIFF
--- a/web/emails/coherence/user_email.ex
+++ b/web/emails/coherence/user_email.ex
@@ -54,14 +54,19 @@ defmodule CoursePlanner.Coherence.UserEmail do
   end
 
   defp first_name(name) do
-    case String.split(name, " ") do
-      [first_name | _] -> first_name
-      _ -> name
+    if name do
+      name
+    else
+      "there"
     end
   end
 
   defp user_email(user) do
-    {user.name, user.email}
+    if user.name do
+      {user.name, user.email}
+    else
+      user.email
+    end
   end
 
   defp from_email do

--- a/web/emails/coherence/user_email.ex
+++ b/web/emails/coherence/user_email.ex
@@ -53,21 +53,11 @@ defmodule CoursePlanner.Coherence.UserEmail do
     end
   end
 
-  defp first_name(name) do
-    if name do
-      name
-    else
-      "there"
-    end
-  end
+  defp first_name(nil), do: "there"
+  defp first_name(name), do: name
 
-  defp user_email(user) do
-    if user.name do
-      {user.name, user.email}
-    else
-      user.email
-    end
-  end
+  defp user_email(%{name: nil, email: email}), do: email
+  defp user_email(%{name: name, email: email}), do: {name, email}
 
   defp from_email do
     log_string = """


### PR DESCRIPTION
Our user has name and family name so we won't split it to send the
email, instead we send with the name.
The user may not have a name, in that case the email should be the email
without name