### PR TITLE
Modified user form to can be used as edit profile form too

### DIFF
--- a/test/controllers/class_controller_test.exs
+++ b/test/controllers/class_controller_test.exs
@@ -1,22 +1,17 @@
 defmodule CoursePlanner.ClassControllerTest do
   use CoursePlanner.ConnCase
 
-  alias CoursePlanner.{Class, Repo, User, Attendance}
+  alias CoursePlanner.{Class, Repo, Attendance}
   import CoursePlanner.Factory
 
   @valid_attrs %{offered_course_id: nil, date: %{day: 17, month: 4, year: 2017}, starting_at: %{hour: 14, min: 0, sec: 0}, finishes_at: %{hour: 15, min: 0, sec: 0}}
   @valid_insert_attrs %{offered_course: nil, date: %{day: 17, month: 4, year: 2017}, starting_at: %{hour: 14, min: 0, sec: 0}, finishes_at: %{hour: 15, min: 0, sec: 0}}
   @invalid_attrs %{}
-  @user %User{
-    name: "Test User",
-    email: "testuser@example.com",
-    password: "secret",
-    password_confirmation: "secret"}
 
   setup do
     conn =
       Phoenix.ConnTest.build_conn()
-        |> assign(:current_user, @user)
+        |> assign(:current_user, insert(:coordinator))
     {:ok, conn: conn}
   end
 

--- a/test/controllers/course_controller_test.exs
+++ b/test/controllers/course_controller_test.exs
@@ -1,22 +1,16 @@
 defmodule CoursePlanner.CourseControllerTest do
   use CoursePlanner.ConnCase
-  alias CoursePlanner.User
   alias CoursePlanner.Course
 
   import CoursePlanner.Factory
 
   @valid_attrs %{description: "some content", name: "some content"}
   @invalid_attrs %{}
-  @user %User{
-    name: "Test User",
-    email: "testuser@example.com",
-    password: "secret",
-    password_confirmation: "secret"}
 
   setup do
     conn =
       Phoenix.ConnTest.build_conn()
-        |> assign(:current_user, @user)
+        |> assign(:current_user, insert(:coordinator))
     {:ok, conn: conn}
   end
 

--- a/test/controllers/dashboard_controller_test.exs
+++ b/test/controllers/dashboard_controller_test.exs
@@ -4,7 +4,7 @@ defmodule CoursePlanner.DashboardControllerTest do
   import CoursePlanner.Factory
 
   setup do
-    user = build(:coordinator)
+    user = insert(:coordinator)
 
     conn =
       Phoenix.ConnTest.build_conn()

--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -1,18 +1,12 @@
 defmodule CoursePlanner.TaskControllerTest do
   use CoursePlanner.ConnCase
-  alias CoursePlanner.{Tasks, Volunteers, Repo, User}
+  alias CoursePlanner.{Tasks, Volunteers, Repo}
   alias CoursePlanner.Tasks.Task
 
   import CoursePlanner.Factory
 
   @valid_attrs %{name: "some content", start_time: Timex.now(), finish_time: Timex.now()}
   @invalid_attrs %{}
-  @user %User{
-    name: "Test User",
-    email: "testuser@example.com",
-    password: "secret",
-    password_confirmation: "secret",
-    role: "Coordinator"}
   @volunteer %{
     name: "Test Volunteer",
     email: "volunteer@courseplanner.com",
@@ -23,7 +17,7 @@ defmodule CoursePlanner.TaskControllerTest do
   setup do
     conn =
       Phoenix.ConnTest.build_conn()
-        |> assign(:current_user, @user)
+        |> assign(:current_user, insert(:coordinator))
     {:ok, conn: conn}
   end
 

--- a/web/static/css/card.scss
+++ b/web/static/css/card.scss
@@ -6,6 +6,7 @@
 
   .card {
     margin: 20px 0;
+    position: relative;
 
     &__title {
       &--highlighted {

--- a/web/static/css/layout.scss
+++ b/web/static/css/layout.scss
@@ -8,9 +8,30 @@
   }
 
   .profile-bubble {
+    &__wrapper {
+      position: relative;
+    }
+
     &__image {
       width: 40px;
       height: 40px;
       border-radius: 50%;
+    }
+
+    &--form {
+      position: absolute;
+      top: 16px;
+      right: 16px;
+
+      .profile-bubble__image {
+        width: 60px;
+        height: 60px;
+      }
+    }
+
+    &__button {
+      border: 0;
+      background: transparent;
+      cursor: pointer;
     }
   }

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -29,12 +29,27 @@
             <%= @view_module.page_title %>
           </span>
           <div class="mdl-layout-spacer"></div>
-          <nav class="mdl-navigation">
-            <%= CoursePlanner.Coherence.ViewHelpers.signout_link(@conn, "Sign out", "mdl-navigation__link") %>
-            <img
-              class="profile-bubble__image"
-              src="<%= CoursePlanner.SharedView.get_gravatar_url( @conn.assigns.current_user.email ) %>"
-            />
+          <nav class="mdl-navigation profile-bubble__wrapper">
+            <%= @conn.assigns.current_user.name %>
+            <%= @conn.assigns.current_user.family_name %>
+            <button id="profile_dropdown"
+                    class="profile-bubble__button"
+            >
+              <img
+                class="profile-bubble__image"
+                src="<%= CoursePlanner.SharedView.get_gravatar_url( @conn.assigns.current_user.email ) %>"
+              />
+            </button>
+            <ul class="mdl-menu mdl-menu--bottom-right mdl-js-menu"
+                for="profile_dropdown"
+            >
+              <li class="mdl-menu__item">
+                <%= link "Edit profile", to: user_path(@conn, :edit, @conn.assigns.current_user) %>
+              </li>
+              <li class="mdl-menu__item">
+                <%= CoursePlanner.Coherence.ViewHelpers.signout_link(@conn, "Sign out") %>
+              </li>
+            </ul>
           </nav>
         </div>
       </header>

--- a/web/templates/user/form.html.eex
+++ b/web/templates/user/form.html.eex
@@ -1,5 +1,6 @@
 
   <% roles = ["Student", "Teacher", "Coordinator", "Volunteer"] %>
+  <% own = @conn.assigns.current_user.id === @conn.assigns.user.id %>
 
   <div class="row">
     <div class="col-xs-12 col-md-6 col-md-offset-3">
@@ -11,13 +12,33 @@
                 <p>Oops, something went wrong! Please check the errors below.</p>
               </div>
             <% end %>
+            <%= if own do %>
+              <a
+                class="profile-bubble profile-bubble--form"
+                href="https://en.gravatar.com/support/"
+                target="_blank"
+                rel="noopener noreferrer"
+                id="change_profile_gravatar"
+              >
+                <img
+                  class="profile-bubble__image"
+                  src="<%= CoursePlanner.SharedView.get_gravatar_url( @conn.assigns.current_user.email ) %>"
+                />
+              </a>
+              <div class="mdl-tooltip mdl-tooltip--right" data-mdl-for="change_profile_gravatar">
+                Change your avatar at gravatar.com
+              </div>
+            <% end %>
             <%= CoursePlanner.SharedView.form_text f, :name %>
             <%= CoursePlanner.SharedView.form_text f, :family_name %>
             <%= CoursePlanner.SharedView.form_text f, :nickname %>
             <%= CoursePlanner.SharedView.form_text f, :email, required: true %>
-            <%= CoursePlanner.SharedView.form_text f, :student_id %>
-            <%= CoursePlanner.SharedView.form_text f, :comments %>
-            <%= CoursePlanner.SharedView.form_select f, :role, roles %>
+            <%= if own && @conn.assigns.current_user.role !== "Student" do %>
+              <%= CoursePlanner.SharedView.form_text f, :phone_number %>
+            <% end %>
+            <%= if @conn.assigns.current_user.role === "Coordinator" do %>
+              <%= CoursePlanner.SharedView.form_select f, :role, roles %>
+            <% end %>
           <% end %>
           <%= CoursePlanner.SharedView.card_actions do %>
             <div class="row row--vspace">


### PR DESCRIPTION
* Added profile dropdown to the navigation bar
* Removed student related fields (they are accessible from the student
form)
* Adedd profile-picture, with gravatar link
* Added phone number, so Coordinators, Teachers, and Volunteers can edit
their own
* Added condition to role selector, so only Coordinators can change it