### PR TITLE
Introduces categorized show and edit for system variables

### DIFF
--- a/test/controllers/setting_controller_test.exs
+++ b/test/controllers/setting_controller_test.exs
@@ -13,20 +13,28 @@ defmodule CoursePlanner.SettingControllerTest do
     {:ok, conn: conn}
   end
 
+  @moduletag user_role: :coordinator
   describe "settings functionality for coordinator user" do
-    @tag user_role: :coordinator
     test "shows chosen resource only for coordinator", %{conn: conn} do
       conn = get conn, setting_path(conn, :show)
       assert html_response(conn, 200) =~ "Show settings"
     end
 
-    @tag user_role: :coordinator
-    test "renders form for editing for coordinator", %{conn: conn} do
-      conn = get conn, setting_path(conn, :edit)
+    test "renders form for editing system setting for coordinator", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
       assert html_response(conn, 200) =~ "Edit settings"
     end
 
-    @tag user_role: :coordinator
+    test "renders form for editing program setting for coordinator", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      assert html_response(conn, 200) =~ "Edit settings"
+    end
+
+    test "renders 404 if request is notsystem_settings nor program_settings", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "random")
+      assert html_response(conn, 404)
+    end
+
     test "does not update chosen resource and renders errors when data is invalid for coordinator user", %{conn: conn} do
       system_variable = insert(:system_variable)
       updated_params = %{system_variables: %{"0" => %{id: "#{system_variable.id}", value: ""}}}
@@ -36,7 +44,6 @@ defmodule CoursePlanner.SettingControllerTest do
       assert html_response(conn, 200) =~ "can&#39;t be blank"
     end
 
-    @tag user_role: :coordinator
     test "updates chosen resource and redirects when data is valid for coordinator user", %{conn: conn} do
       system_variable = insert(:system_variable)
       updating_value = "new program name"
@@ -47,7 +54,6 @@ defmodule CoursePlanner.SettingControllerTest do
       assert Repo.get(SystemVariable, system_variable.id).value == updating_value
     end
 
-    @tag user_role: :coordinator
     test "does not update chosen resource when is not editable", %{conn: conn} do
       insert(:system_variable)
       system_variable = insert(:system_variable, %{editable: false})
@@ -60,7 +66,6 @@ defmodule CoursePlanner.SettingControllerTest do
       refute Repo.get(SystemVariable, system_variable.id).value == updating_value
     end
 
-    @tag user_role: :coordinator
     test "does not update chosen inexisting resource", %{conn: conn} do
       updated_params = %{system_variables: %{"0" => %{id: "-1", value: "random value"}}}
 
@@ -70,20 +75,23 @@ defmodule CoursePlanner.SettingControllerTest do
     end
   end
 
+  @moduletag user_role: :student
   describe "setting functionality for student user" do
-    @tag user_role: :student
     test "student can't see settings", %{conn: conn} do
       conn = get conn, setting_path(conn, :show)
       assert html_response(conn, 403)
     end
 
-    @tag user_role: :student
-    test "student cannot edit settings", %{conn: conn} do
-      conn = get conn, setting_path(conn, :edit)
+    test "student cannot edit system settings", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
       assert html_response(conn, 403)
     end
 
-    @tag user_role: :student
+    test "student cannot edit program settings", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      assert html_response(conn, 403)
+    end
+
     test "student can't update settings", %{conn: conn} do
       system_variable = insert(:system_variable)
       updated_params = %{system_variables: %{"0" => %{id: "#{system_variable.id}", value: "new program name"}}}
@@ -93,20 +101,23 @@ defmodule CoursePlanner.SettingControllerTest do
     end
   end
 
+  @moduletag user_role: :teacher
   describe "settings functionality for teacher user" do
-    @tag user_role: :teacher
     test "teacher can't see settings", %{conn: conn} do
       conn = get conn, setting_path(conn, :show)
       assert html_response(conn, 403)
     end
 
-    @tag user_role: :teacher
-    test "teacher cannot edit settings", %{conn: conn} do
-      conn = get conn, setting_path(conn, :edit)
+    test "teacher cannot edit system settings", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
       assert html_response(conn, 403)
     end
 
-    @tag user_role: :teacher
+    test "teacher cannot edit program settings", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      assert html_response(conn, 403)
+    end
+
     test "teacher can't update settings", %{conn: conn} do
       system_variable = insert(:system_variable)
       updated_params = %{system_variables: %{"0" => %{id: "#{system_variable.id}", value: "new program name"}}}
@@ -116,20 +127,23 @@ defmodule CoursePlanner.SettingControllerTest do
     end
   end
 
+  @tag user_role: :volunteer
   describe "settings functionality for volunteer user" do
-    @tag user_role: :volunteer
     test "volunteer can't see settings", %{conn: conn} do
       conn = get conn, setting_path(conn, :show)
       assert html_response(conn, 403)
     end
 
-    @tag user_role: :volunteer
-    test "volunteer cannot edit settings", %{conn: conn} do
-      conn = get conn, setting_path(conn, :edit)
+    test "volunteer cannot edit system settings", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
       assert html_response(conn, 403)
     end
 
-    @tag user_role: :volunteer
+    test "volunteer cannot edit programsettings", %{conn: conn} do
+      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      assert html_response(conn, 403)
+    end
+
     test "volunteer can't update settings", %{conn: conn} do
       system_variable = insert(:system_variable)
       updated_params = %{system_variables: %{"0" => %{id: "#{system_variable.id}", value: "new program name"}}}

--- a/test/controllers/setting_controller_test.exs
+++ b/test/controllers/setting_controller_test.exs
@@ -21,17 +21,17 @@ defmodule CoursePlanner.SettingControllerTest do
     end
 
     test "renders form for editing system setting for coordinator", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "system")
       assert html_response(conn, 200) =~ "Edit settings"
     end
 
     test "renders form for editing program setting for coordinator", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "program")
       assert html_response(conn, 200) =~ "Edit settings"
     end
 
     test "renders 404 if request is notsystem_settings nor program_settings", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "random")
+      conn = get conn, setting_path(conn, :edit, setting_type: "random")
       assert html_response(conn, 404)
     end
 
@@ -83,12 +83,12 @@ defmodule CoursePlanner.SettingControllerTest do
     end
 
     test "student cannot edit system settings", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "system")
       assert html_response(conn, 403)
     end
 
     test "student cannot edit program settings", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "program")
       assert html_response(conn, 403)
     end
 
@@ -109,12 +109,12 @@ defmodule CoursePlanner.SettingControllerTest do
     end
 
     test "teacher cannot edit system settings", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "system")
       assert html_response(conn, 403)
     end
 
     test "teacher cannot edit program settings", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "program")
       assert html_response(conn, 403)
     end
 
@@ -127,7 +127,7 @@ defmodule CoursePlanner.SettingControllerTest do
     end
   end
 
-  @tag user_role: :volunteer
+  @moduletag user_role: :volunteer
   describe "settings functionality for volunteer user" do
     test "volunteer can't see settings", %{conn: conn} do
       conn = get conn, setting_path(conn, :show)
@@ -135,12 +135,12 @@ defmodule CoursePlanner.SettingControllerTest do
     end
 
     test "volunteer cannot edit system settings", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "system_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "system")
       assert html_response(conn, 403)
     end
 
     test "volunteer cannot edit programsettings", %{conn: conn} do
-      conn = get conn, setting_edit_path(conn, :edit, "program_settings")
+      conn = get conn, setting_path(conn, :edit, setting_type: "program")
       assert html_response(conn, 403)
     end
 

--- a/web/controllers/setting_controller.ex
+++ b/web/controllers/setting_controller.ex
@@ -18,22 +18,16 @@ defmodule CoursePlanner.SettingController do
                               non_program_system_variables: non_program_system_variables)
   end
 
-  def edit(%{assigns: %{current_user: %{role: "Coordinator"}}} = conn, param) do
+  def edit(%{assigns: %{current_user: %{role: "Coordinator"}}} = conn,
+           %{"setting_type" =>  setting_type}) do
     editable_system_variables = Settings.get_editable_systemvariables()
 
-    filtered_system_variables =
-      case Map.get(param, "setting_type") do
-        "system_settings"  -> Settings.filter_non_program_systemvariables(editable_system_variables)
-        "program_settings" -> Settings.filter_program_systemvariables(editable_system_variables)
-        _                  -> nil
-      end
-
-    case filtered_system_variables do
-      nil ->
+    case Settings.filter_system_variables(editable_system_variables, setting_type) do
+      {:error, _} ->
         conn
         |> put_status(404)
         |> render(CoursePlanner.ErrorView, "404.html")
-      _   ->
+      {:ok, filtered_system_variables} ->
         changeset =
           filtered_system_variables
           |> Enum.map(&SystemVariable.changeset/1)

--- a/web/controllers/setting_controller.ex
+++ b/web/controllers/setting_controller.ex
@@ -23,10 +23,6 @@ defmodule CoursePlanner.SettingController do
     editable_system_variables = Settings.get_editable_systemvariables()
 
     case Settings.filter_system_variables(editable_system_variables, setting_type) do
-      {:error, _} ->
-        conn
-        |> put_status(404)
-        |> render(CoursePlanner.ErrorView, "404.html")
       {:ok, filtered_system_variables} ->
         changeset =
           filtered_system_variables
@@ -34,6 +30,10 @@ defmodule CoursePlanner.SettingController do
           |> Settings.wrap()
 
         render(conn, "edit.html", changeset: changeset)
+      {:error, _} ->
+        conn
+        |> put_status(404)
+        |> render(CoursePlanner.ErrorView, "404.html")
     end
   end
 

--- a/web/models/setting/settings.ex
+++ b/web/models/setting/settings.ex
@@ -39,14 +39,14 @@ defmodule CoursePlanner.Settings do
 
   def filter_system_variables(system_variables, setting_type) do
       case setting_type do
-        "system_settings"  -> {:ok, filter_non_program_systemvariables(system_variables)}
-        "program_settings" -> {:ok, filter_program_systemvariables(system_variables)}
+        "system"  -> {:ok, filter_non_program_systemvariables(system_variables)}
+        "program" -> {:ok, filter_program_systemvariables(system_variables)}
         _                  -> {:error, nil}
       end
   end
 
   def filter_non_program_systemvariables(settings) do
-    Enum.filter(settings, &(not String.starts_with?(&1.key, "PROGRAM")))
+    Enum.reject(settings, &(String.starts_with?(&1.key, "PROGRAM")))
   end
 
   def filter_program_systemvariables(settings) do

--- a/web/models/setting/settings.ex
+++ b/web/models/setting/settings.ex
@@ -37,12 +37,20 @@ defmodule CoursePlanner.Settings do
     parsed_value
   end
 
+  def filter_system_variables(system_variables, setting_type) do
+      case setting_type do
+        "system_settings"  -> {:ok, filter_non_program_systemvariables(system_variables)}
+        "program_settings" -> {:ok, filter_program_systemvariables(system_variables)}
+        _                  -> {:error, nil}
+      end
+  end
+
   def filter_non_program_systemvariables(settings) do
-    Enum.reject(settings, &(String.starts_with?(&1.key, "PROGRAM")))
+    Enum.filter(settings, &(not String.starts_with?(&1.key, "PROGRAM")))
   end
 
   def filter_program_systemvariables(settings) do
-    Enum.reject(settings, &(not String.starts_with?(&1.key, "PROGRAM")))
+    Enum.filter(settings, &(String.starts_with?(&1.key, "PROGRAM")))
   end
 
   def get_visible_systemvariables do

--- a/web/models/setting/settings.ex
+++ b/web/models/setting/settings.ex
@@ -37,6 +37,14 @@ defmodule CoursePlanner.Settings do
     parsed_value
   end
 
+  def filter_non_program_systemvariables(settings) do
+    Enum.reject(settings, &(String.starts_with?(&1.key, "PROGRAM")))
+  end
+
+  def filter_program_systemvariables(settings) do
+    Enum.reject(settings, &(not String.starts_with?(&1.key, "PROGRAM")))
+  end
+
   def get_visible_systemvariables do
     Repo.all(@visible_settings_query)
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -74,7 +74,9 @@ defmodule CoursePlanner.Router do
       put "/update_fill", AttendanceController, :update_fill, as: :update_fill
     end
 
-    resources "/settings", SettingController, only: [:show, :edit, :update], singleton: true
+    resources "/settings", SettingController, only: [:show, :update], singleton: true do
+      get "/:setting_type", SettingController, :edit, as: :edit
+    end
   end
 
   if Mix.env == :dev do

--- a/web/router.ex
+++ b/web/router.ex
@@ -74,9 +74,7 @@ defmodule CoursePlanner.Router do
       put "/update_fill", AttendanceController, :update_fill, as: :update_fill
     end
 
-    resources "/settings", SettingController, only: [:show, :update], singleton: true do
-      get "/:setting_type", SettingController, :edit, as: :edit
-    end
+    resources "/settings", SettingController, only: [:show, :edit, :update], singleton: true
   end
 
   if Mix.env == :dev do

--- a/web/templates/setting/show.html.eex
+++ b/web/templates/setting/show.html.eex
@@ -1,5 +1,6 @@
 <h2>Show settings</h2>
 
+<h3>System settings</h3>
 <table class="table">
   <thead>
     <tr>
@@ -8,7 +9,7 @@
     </tr>
   </thead>
   <tbody>
-    <%= for system_variable <- @system_variables do %>
+    <%= for system_variable <- @non_program_system_variables do %>
       <tr>
         <td><%= system_variable.key %></td>
         <td><%= system_variable.value %></td>
@@ -17,4 +18,24 @@
   </tbody>
 </table>
 
-<%= link "Edit", to: setting_path(@conn, :edit) %>
+<%= link "Edit system setting", to: setting_edit_path(@conn, :edit, "system_settings") %>
+
+<h3>Program settings</h3>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for system_variable <- @program_system_variables do %>
+      <tr>
+        <td><%= system_variable.key %></td>
+        <td><%= system_variable.value %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link "Edit program setting", to: setting_edit_path(@conn, :edit, "program_settings") %>

--- a/web/templates/setting/show.html.eex
+++ b/web/templates/setting/show.html.eex
@@ -18,7 +18,7 @@
   </tbody>
 </table>
 
-<%= link "Edit system setting", to: setting_edit_path(@conn, :edit, "system_settings") %>
+<%= link "Edit system setting", to: setting_path(@conn, :edit, setting_type: "system") %>
 
 <h3>Program settings</h3>
 <table class="table">
@@ -38,4 +38,4 @@
   </tbody>
 </table>
 
-<%= link "Edit program setting", to: setting_edit_path(@conn, :edit, "program_settings") %>
+<%= link "Edit program setting", to: setting_path(@conn, :edit, setting_type: "program") %>


### PR DESCRIPTION
1. Separates the system_variables to system and program and uses two different tables to list them in the show page
2. introduces two separate edit link for editing system and program related system variables separately
3. updates the router so edit can get an id to select editing between system or program system_variables
4. updates the current tests and introduces new ones