### PR TITLE
creates summary page helpers

### DIFF
--- a/test/controllers/class_controller_test.exs
+++ b/test/controllers/class_controller_test.exs
@@ -4,8 +4,8 @@ defmodule CoursePlanner.ClassControllerTest do
   alias CoursePlanner.{Class, Repo, Attendance}
   import CoursePlanner.Factory
 
-  @valid_attrs %{offered_course_id: nil, date: %{day: 17, month: 4, year: 2017}, starting_at: %{hour: 14, min: 0, sec: 0}, finishes_at: %{hour: 15, min: 0, sec: 0}}
-  @valid_insert_attrs %{offered_course: nil, date: %{day: 17, month: 4, year: 2017}, starting_at: %{hour: 14, min: 0, sec: 0}, finishes_at: %{hour: 15, min: 0, sec: 0}}
+  @valid_attrs %{offered_course_id: nil, date: Timex.now(), starting_at: %{hour: 14, min: 0, sec: 0}, finishes_at: %{hour: 15, min: 0, sec: 0}}
+  @valid_insert_attrs %{offered_course: nil, date: Timex.now(), starting_at: %{hour: 14, min: 0, sec: 0}, finishes_at: %{hour: 15, min: 0, sec: 0}}
   @invalid_attrs %{}
 
   setup do
@@ -191,8 +191,8 @@ defmodule CoursePlanner.ClassControllerTest do
   test "creates class and all attendance", %{conn: conn} do
     course = insert(:course)
     term1 = insert(:term, %{
-                            start_date: %Ecto.Date{day: 1, month: 1, year: 2017},
-                            end_date: %Ecto.Date{day: 1, month: 6, year: 2017},
+                            start_date: Timex.shift(Timex.now(), months: -2),
+                            end_date: Timex.shift(Timex.now(), months: 4),
                             courses: [course]
                            })
 

--- a/test/models/class_test.exs
+++ b/test/models/class_test.exs
@@ -4,10 +4,10 @@ defmodule CoursePlanner.ClassTest do
   import CoursePlanner.Factory
   alias CoursePlanner.{Class, Repo}
 
-  @valid_attrs %{offered_course_id: nil, date: %{day: 17, month: 4, year: 2017}, finishes_at: %{hour: 15, min: 0, sec: 0}, starting_at: %{hour: 14, min: 0, sec: 0}}
+  @valid_attrs %{offered_course_id: nil, date: Timex.now(), finishes_at: %{hour: 15, min: 0, sec: 0}, starting_at: %{hour: 14, min: 0, sec: 0}}
   @invalid_attrs %{}
-  @class_before_term %{offered_course_id: nil, date: %{day: 17, month: 4, year: 2009}, finishes_at: %{hour: 14, min: 0, sec: 0}, starting_at: %{hour: 14, min: 0, sec: 0}}
-  @class_after_term %{offered_course_id: nil, date: %{day: 17, month: 4, year: 2011}, finishes_at: %{hour: 14, min: 0, sec: 0}, starting_at: %{hour: 14, min: 0, sec: 0}}
+  @class_before_term %{offered_course_id: nil, date: Timex.shift(Timex.now(), years: -2), finishes_at: %{hour: 14, min: 0, sec: 0}, starting_at: %{hour: 14, min: 0, sec: 0}}
+  @class_after_term %{offered_course_id: nil, date: Timex.shift(Timex.now(), months: 2), finishes_at: %{hour: 14, min: 0, sec: 0}, starting_at: %{hour: 14, min: 0, sec: 0}}
 
   test "changeset with valid attributes" do
     created_course = insert(:offered_course)
@@ -40,9 +40,9 @@ defmodule CoursePlanner.ClassTest do
   test "update class with invalid date" do
     oc = insert(:offered_course)
     {:ok, class} = Class.changeset(%Class{}, %{@valid_attrs | offered_course_id: oc.id}) |> Repo.insert()
-    changeset = Class.changeset(class, %{date: %{day: 17, month: 7, year: 2017}}, :update)
+    changeset = Class.changeset(class, %{date: Timex.shift(Timex.now(), months: 3)}, :update)
     refute changeset.valid?
-    changeset = Class.changeset(class, %{date: %{day: 17, month: 4, year: 2017}}, :update)
+    changeset = Class.changeset(class, %{date: Timex.now()}, :update)
     assert changeset.valid?
   end
 

--- a/test/models/summary_helper_test.exs
+++ b/test/models/summary_helper_test.exs
@@ -1,0 +1,343 @@
+defmodule CoursePlanner.SummaryHelperTest do
+  use CoursePlanner.ModelCase
+
+  import CoursePlanner.Factory
+  alias CoursePlanner.SummaryHelper
+
+  @empty_summary_helper_user_data_response %{terms: [], offered_courses: []}
+
+  test "when user role is unknown" do
+    student = insert(:student)
+    [term1, term2] = insert_list(2, :term)
+    insert_list(4, :offered_course, term: term1)
+    insert(:offered_course, term: term2, students: [student])
+
+    student_data = SummaryHelper.get_term_offered_course_for_user(student.id, "Unknown")
+    assert student_data == @empty_summary_helper_user_data_response
+  end
+
+  describe "Student summary data" do
+    test "when she does not exist" do
+      student_data = SummaryHelper.get_term_offered_course_for_user(-1, "Student")
+      assert student_data == @empty_summary_helper_user_data_response
+    end
+
+    test "when she is not registered to any offered_course" do
+      student = insert(:student)
+      insert(:class)
+
+      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
+      assert student_data == @empty_summary_helper_user_data_response
+    end
+
+    test "when she has a course in one term" do
+      student = insert(:student)
+      [term1, term2] = insert_list(2, :term)
+
+      insert_list(4, :offered_course, term: term1)
+      offered_course =
+        insert(:offered_course, term: term2, students: [student])
+        |> Repo.preload(:classes)
+
+      student_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: [offered_course]}
+
+      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
+      assert student_data == student_summary_data_response
+    end
+
+    test "when she has multiple courses in one term" do
+      student = insert(:student)
+      [term1, term2] = insert_list(2, :term)
+
+      insert_list(2, :offered_course, term: term1)
+      offered_courses =
+        insert_list(2, :offered_course, term: term2, students: [student])
+        |> Repo.preload(:classes)
+
+      student_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses}
+
+      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
+      assert student_data == student_summary_data_response
+    end
+
+    test "when she has multiple courses in multiple terms" do
+      student = insert(:student)
+      [term1, term2] = insert_list(2, :term)
+
+      offered_courses1 =
+        insert_list(2, :offered_course, term: term1, students: [student])
+        |> Repo.preload(:classes)
+
+      offered_courses2 =
+        insert_list(2, :offered_course, term: term2, students: [student])
+        |> Repo.preload(:classes)
+
+      student_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: offered_courses1 ++ offered_courses2}
+
+      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
+      assert student_data == student_summary_data_response
+    end
+
+    test "when she has multiple courses the end_date of all terms are passed" do
+      student = insert(:student)
+      [term1, term2] = insert_list(2, :term, end_date: Timex.shift(Timex.now(), days: -2))
+
+      insert_list(2, :offered_course, term: term1, students: [student])
+      insert_list(2, :offered_course, term: term2, students: [student])
+
+      assert SummaryHelper.get_term_offered_course_for_user(student.id, student.role) == @empty_summary_helper_user_data_response
+    end
+
+    test "when she has multiple courses excluding the term that is finished and its data" do
+      student = insert(:student)
+      term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -2))
+      term2 = insert(:term)
+
+      insert_list(2, :offered_course, term: term1, students: [student])
+      offered_courses2 =
+        insert_list(2, :offered_course, term: term2, students: [student])
+        |> Repo.preload(:classes)
+
+      student_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses2}
+
+      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
+      assert student_data == student_summary_data_response
+    end
+  end
+
+  describe "Teacher summary data" do
+    test "when she does not exist" do
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(-1, "Teacher")
+      assert teacher_data == @empty_summary_helper_user_data_response
+    end
+
+    test "when she is not registered to any offered_course" do
+      teacher = insert(:teacher)
+      insert(:class)
+
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
+      assert teacher_data == @empty_summary_helper_user_data_response
+    end
+
+    test "when she has a course in one term" do
+      teacher = insert(:teacher)
+      [term1, term2] = insert_list(2, :term)
+
+      insert_list(4, :offered_course, term: term1)
+      offered_course =
+        insert(:offered_course, term: term2, teachers: [teacher])
+        |> Repo.preload(:classes)
+
+      teacher_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: [offered_course]}
+
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
+      assert teacher_data == teacher_summary_data_response
+    end
+
+    test "when she has multiple courses in one term" do
+      teacher = insert(:teacher)
+      [term1, term2] = insert_list(2, :term)
+
+      insert_list(2, :offered_course, term: term1)
+      offered_courses =
+        insert_list(2, :offered_course, term: term2, teachers: [teacher])
+        |> Repo.preload(:classes)
+
+      teacher_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses}
+
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
+      assert teacher_data == teacher_summary_data_response
+    end
+
+    test "when she has multiple courses in multiple terms" do
+      teacher = insert(:teacher)
+      [term1, term2] = insert_list(2, :term)
+
+      offered_courses1 =
+        insert_list(2, :offered_course, term: term1, teachers: [teacher])
+        |> Repo.preload(:classes)
+
+      offered_courses2 =
+        insert_list(2, :offered_course, term: term2, teachers: [teacher])
+        |> Repo.preload(:classes)
+
+      teacher_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: offered_courses1 ++ offered_courses2}
+
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
+      assert teacher_data == teacher_summary_data_response
+    end
+
+    test "when she has multiple courses excluding the term that is finished and its data" do
+      teacher = insert(:teacher)
+      term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -2))
+      term2 = insert(:term)
+
+      insert_list(2, :offered_course, term: term1, teachers: [teacher])
+      offered_courses2 =
+        insert_list(2, :offered_course, term: term2, teachers: [teacher])
+        |> Repo.preload(:classes)
+
+      teacher_summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses2}
+
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
+      assert teacher_data == teacher_summary_data_response
+    end
+
+    test "when she has multiple courses the end_date of all terms are passed" do
+      teacher = insert(:teacher)
+      [term1, term2] = insert_list(2, :term, end_date: Timex.shift(Timex.now(), days: -2))
+
+      insert_list(2, :offered_course, term: term1, teachers: [teacher])
+      insert_list(2, :offered_course, term: term2, teachers: [teacher])
+
+      assert SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role) == @empty_summary_helper_user_data_response
+    end
+  end
+
+  describe "Coordinator summary data" do
+    test "when there is no term" do
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+
+      assert summary_data == @empty_summary_helper_user_data_response
+    end
+
+    test "when there are terms but no offered_course" do
+      terms = insert_list(2, :term)
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+
+      assert summary_data == %{@empty_summary_helper_user_data_response | terms: terms}
+    end
+
+    test "when only one term has offered_course" do
+      [term1, term2] = insert_list(2, :term)
+      term2_offered_course =
+        insert(:offered_course, term: term2)
+        |> Repo.preload(:classes)
+
+      summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: [term2_offered_course]}
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+
+      assert summary_data == summary_data_response
+    end
+
+    test "when each term has offered_courses" do
+      [term1, term2] = insert_list(2, :term)
+      term1_offered_course =
+        insert(:offered_course, term: term1)
+        |> Repo.preload(:classes)
+      term2_offered_courses = insert_list(4, :offered_course, term: term2)
+
+      expected_offered_courses = preload_associations_for_offered_courses([term1_offered_course | term2_offered_courses])
+      summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: expected_offered_courses}
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+
+      assert summary_data == summary_data_response
+    end
+
+    test "when term end time is past all it's data will be excluded" do
+      term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -2))
+      term2 = insert(:term)
+      insert(:offered_course, term: term1)
+      term2_offered_courses = insert_list(4, :offered_course, term: term2)
+
+      expected_offered_courses = preload_associations_for_offered_courses(term2_offered_courses)
+      summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: expected_offered_courses}
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+
+      assert summary_data == summary_data_response
+    end
+
+    test "no data returns when every term's end date is passed" do
+      term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -10))
+      term2 = insert(:term, end_date: Timex.shift(Timex.now(), days: -20))
+      insert_list(6, :offered_course, term: term1)
+      insert_list(4, :offered_course, term: term2)
+
+      assert SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator") == @empty_summary_helper_user_data_response
+    end
+  end
+
+  describe "Volunteer summary data" do
+    test "when there is no term" do
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+
+      assert summary_data == @empty_summary_helper_user_data_response
+    end
+
+    test "when there are terms but no offered_course" do
+      terms = insert_list(2, :term)
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+
+      assert summary_data == %{@empty_summary_helper_user_data_response | terms: terms}
+    end
+
+    test "when only one term has offered_course" do
+      [term1, term2] = insert_list(2, :term)
+      term2_offered_course =
+        insert(:offered_course, term: term2)
+        |> Repo.preload(:classes)
+
+      summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: [term2_offered_course]}
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+
+      assert summary_data == summary_data_response
+    end
+
+    test "when each term has offered_courses" do
+      [term1, term2] = insert_list(2, :term)
+      term1_offered_course =
+        insert(:offered_course, term: term1)
+        |> Repo.preload(:classes)
+      term2_offered_courses = insert_list(4, :offered_course, term: term2)
+
+      expected_offered_courses = preload_associations_for_offered_courses([term1_offered_course | term2_offered_courses])
+      summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: expected_offered_courses}
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+
+      assert summary_data == summary_data_response
+    end
+
+    test "when term end time is past all it's data will be excluded" do
+      term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -2))
+      term2 = insert(:term)
+      insert(:offered_course, term: term1)
+      term2_offered_courses = insert_list(4, :offered_course, term: term2)
+
+      expected_offered_courses = preload_associations_for_offered_courses(term2_offered_courses)
+      summary_data_response =
+        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: expected_offered_courses}
+      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+
+      assert summary_data == summary_data_response
+    end
+
+    test "no data returns when every term's end date is passed" do
+      term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -10))
+      term2 = insert(:term, end_date: Timex.shift(Timex.now(), days: -20))
+      insert_list(6, :offered_course, term: term1)
+      insert_list(4, :offered_course, term: term2)
+
+      assert SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator") == @empty_summary_helper_user_data_response
+    end
+  end
+
+  defp preload_associations_for_offered_courses(offered_courses) do
+    offered_courses
+    |> Enum.map(fn(offered_course) ->
+         Repo.preload(offered_course, [:classes])
+       end)
+  end
+end

--- a/test/models/summary_helper_test.exs
+++ b/test/models/summary_helper_test.exs
@@ -18,7 +18,7 @@ defmodule CoursePlanner.SummaryHelperTest do
 
   describe "Student summary data" do
     test "when she does not exist" do
-      student = build(:student, id: -1, role: "Students")
+      student = build(:student, id: -1)
       student_data = SummaryHelper.get_term_offered_course_for_user(student)
       assert student_data == @empty_summary_helper_user_data_response
     end

--- a/test/models/summary_helper_test.exs
+++ b/test/models/summary_helper_test.exs
@@ -12,13 +12,14 @@ defmodule CoursePlanner.SummaryHelperTest do
     insert_list(4, :offered_course, term: term1)
     insert(:offered_course, term: term2, students: [student])
 
-    student_data = SummaryHelper.get_term_offered_course_for_user(student.id, "Unknown")
+    student_data = SummaryHelper.get_term_offered_course_for_user(%{student | role: "Unknown"})
     assert student_data == @empty_summary_helper_user_data_response
   end
 
   describe "Student summary data" do
     test "when she does not exist" do
-      student_data = SummaryHelper.get_term_offered_course_for_user(-1, "Student")
+      student = build(:student, id: -1, role: "Students")
+      student_data = SummaryHelper.get_term_offered_course_for_user(student)
       assert student_data == @empty_summary_helper_user_data_response
     end
 
@@ -26,7 +27,7 @@ defmodule CoursePlanner.SummaryHelperTest do
       student = insert(:student)
       insert(:class)
 
-      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
+      student_data = SummaryHelper.get_term_offered_course_for_user(student)
       assert student_data == @empty_summary_helper_user_data_response
     end
 
@@ -39,11 +40,8 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert(:offered_course, term: term2, students: [student])
         |> Repo.preload(:classes)
 
-      student_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: [offered_course]}
-
-      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
-      assert student_data == student_summary_data_response
+      student_data = SummaryHelper.get_term_offered_course_for_user(student)
+      assert student_data == %{terms: [term2], offered_courses: [offered_course]}
     end
 
     test "when she has multiple courses in one term" do
@@ -55,11 +53,8 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert_list(2, :offered_course, term: term2, students: [student])
         |> Repo.preload(:classes)
 
-      student_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses}
-
-      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
-      assert student_data == student_summary_data_response
+      student_data = SummaryHelper.get_term_offered_course_for_user(student)
+      assert student_data == %{terms: [term2], offered_courses: offered_courses}
     end
 
     test "when she has multiple courses in multiple terms" do
@@ -74,11 +69,8 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert_list(2, :offered_course, term: term2, students: [student])
         |> Repo.preload(:classes)
 
-      student_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: offered_courses1 ++ offered_courses2}
-
-      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
-      assert student_data == student_summary_data_response
+      student_data = SummaryHelper.get_term_offered_course_for_user(student)
+      assert student_data == %{terms: [term1, term2], offered_courses: offered_courses1 ++ offered_courses2}
     end
 
     test "when she has multiple courses the end_date of all terms are passed" do
@@ -88,7 +80,7 @@ defmodule CoursePlanner.SummaryHelperTest do
       insert_list(2, :offered_course, term: term1, students: [student])
       insert_list(2, :offered_course, term: term2, students: [student])
 
-      assert SummaryHelper.get_term_offered_course_for_user(student.id, student.role) == @empty_summary_helper_user_data_response
+      assert SummaryHelper.get_term_offered_course_for_user(student) == @empty_summary_helper_user_data_response
     end
 
     test "when she has multiple courses excluding the term that is finished and its data" do
@@ -101,17 +93,15 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert_list(2, :offered_course, term: term2, students: [student])
         |> Repo.preload(:classes)
 
-      student_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses2}
-
-      student_data = SummaryHelper.get_term_offered_course_for_user(student.id, student.role)
-      assert student_data == student_summary_data_response
+      student_data = SummaryHelper.get_term_offered_course_for_user(student)
+      assert student_data == %{terms: [term2], offered_courses: offered_courses2}
     end
   end
 
   describe "Teacher summary data" do
     test "when she does not exist" do
-      teacher_data = SummaryHelper.get_term_offered_course_for_user(-1, "Teacher")
+      teacher = build(:teacher, id: -1)
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher)
       assert teacher_data == @empty_summary_helper_user_data_response
     end
 
@@ -119,7 +109,7 @@ defmodule CoursePlanner.SummaryHelperTest do
       teacher = insert(:teacher)
       insert(:class)
 
-      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher)
       assert teacher_data == @empty_summary_helper_user_data_response
     end
 
@@ -132,11 +122,8 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert(:offered_course, term: term2, teachers: [teacher])
         |> Repo.preload(:classes)
 
-      teacher_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: [offered_course]}
-
-      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
-      assert teacher_data == teacher_summary_data_response
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher)
+      assert teacher_data == %{terms: [term2], offered_courses: [offered_course]}
     end
 
     test "when she has multiple courses in one term" do
@@ -148,11 +135,8 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert_list(2, :offered_course, term: term2, teachers: [teacher])
         |> Repo.preload(:classes)
 
-      teacher_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses}
-
-      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
-      assert teacher_data == teacher_summary_data_response
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher)
+      assert teacher_data == %{terms: [term2], offered_courses: offered_courses}
     end
 
     test "when she has multiple courses in multiple terms" do
@@ -167,11 +151,8 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert_list(2, :offered_course, term: term2, teachers: [teacher])
         |> Repo.preload(:classes)
 
-      teacher_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: offered_courses1 ++ offered_courses2}
-
-      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
-      assert teacher_data == teacher_summary_data_response
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher)
+      assert teacher_data == %{terms: [term1, term2], offered_courses: offered_courses1 ++ offered_courses2}
     end
 
     test "when she has multiple courses excluding the term that is finished and its data" do
@@ -184,11 +165,8 @@ defmodule CoursePlanner.SummaryHelperTest do
         insert_list(2, :offered_course, term: term2, teachers: [teacher])
         |> Repo.preload(:classes)
 
-      teacher_summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: offered_courses2}
-
-      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role)
-      assert teacher_data == teacher_summary_data_response
+      teacher_data = SummaryHelper.get_term_offered_course_for_user(teacher)
+      assert teacher_data == %{terms: [term2], offered_courses: offered_courses2}
     end
 
     test "when she has multiple courses the end_date of all terms are passed" do
@@ -198,38 +176,39 @@ defmodule CoursePlanner.SummaryHelperTest do
       insert_list(2, :offered_course, term: term1, teachers: [teacher])
       insert_list(2, :offered_course, term: term2, teachers: [teacher])
 
-      assert SummaryHelper.get_term_offered_course_for_user(teacher.id, teacher.role) == @empty_summary_helper_user_data_response
+      assert SummaryHelper.get_term_offered_course_for_user(teacher) == @empty_summary_helper_user_data_response
     end
   end
 
   describe "Coordinator summary data" do
     test "when there is no term" do
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+      coordinator = build(:coordinator, id: -1)
+      summary_data = SummaryHelper.get_term_offered_course_for_user(coordinator)
 
       assert summary_data == @empty_summary_helper_user_data_response
     end
 
     test "when there are terms but no offered_course" do
+      coordinator = insert(:coordinator)
       terms = insert_list(2, :term)
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+      summary_data = SummaryHelper.get_term_offered_course_for_user(coordinator)
 
-      assert summary_data == %{@empty_summary_helper_user_data_response | terms: terms}
+      assert summary_data == %{terms: terms, offered_courses: []}
     end
 
     test "when only one term has offered_course" do
+      coordinator = insert(:coordinator)
       [term1, term2] = insert_list(2, :term)
       term2_offered_course =
         insert(:offered_course, term: term2)
         |> Repo.preload(:classes)
 
-      summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: [term2_offered_course]}
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
-
-      assert summary_data == summary_data_response
+      summary_data = SummaryHelper.get_term_offered_course_for_user(coordinator)
+      assert summary_data == %{terms: [term1, term2], offered_courses: [term2_offered_course]}
     end
 
     test "when each term has offered_courses" do
+      coordinator = insert(:coordinator)
       [term1, term2] = insert_list(2, :term)
       term1_offered_course =
         insert(:offered_course, term: term1)
@@ -237,65 +216,65 @@ defmodule CoursePlanner.SummaryHelperTest do
       term2_offered_courses = insert_list(4, :offered_course, term: term2)
 
       expected_offered_courses = preload_associations_for_offered_courses([term1_offered_course | term2_offered_courses])
-      summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: expected_offered_courses}
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+      summary_data = SummaryHelper.get_term_offered_course_for_user(coordinator)
 
-      assert summary_data == summary_data_response
+      assert summary_data == %{terms: [term1, term2], offered_courses: expected_offered_courses}
     end
 
     test "when term end time is past all it's data will be excluded" do
+      coordinator = insert(:coordinator)
       term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -2))
       term2 = insert(:term)
       insert(:offered_course, term: term1)
       term2_offered_courses = insert_list(4, :offered_course, term: term2)
 
       expected_offered_courses = preload_associations_for_offered_courses(term2_offered_courses)
-      summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: expected_offered_courses}
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator")
+      summary_data = SummaryHelper.get_term_offered_course_for_user(coordinator)
 
-      assert summary_data == summary_data_response
+      assert summary_data == %{terms: [term2], offered_courses: expected_offered_courses}
     end
 
     test "no data returns when every term's end date is passed" do
+      coordinator = insert(:coordinator)
       term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -10))
       term2 = insert(:term, end_date: Timex.shift(Timex.now(), days: -20))
       insert_list(6, :offered_course, term: term1)
       insert_list(4, :offered_course, term: term2)
 
-      assert SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator") == @empty_summary_helper_user_data_response
+      assert SummaryHelper.get_term_offered_course_for_user(coordinator) == @empty_summary_helper_user_data_response
     end
   end
 
   describe "Volunteer summary data" do
     test "when there is no term" do
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+      volunteer = build(:volunteer, id: -1)
+      summary_data = SummaryHelper.get_term_offered_course_for_user(volunteer)
 
       assert summary_data == @empty_summary_helper_user_data_response
     end
 
     test "when there are terms but no offered_course" do
+      volunteer = insert(:volunteer)
       terms = insert_list(2, :term)
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+      summary_data = SummaryHelper.get_term_offered_course_for_user(volunteer)
 
-      assert summary_data == %{@empty_summary_helper_user_data_response | terms: terms}
+      assert summary_data == %{terms: terms, offered_courses: []}
     end
 
     test "when only one term has offered_course" do
+      volunteer = insert(:volunteer)
       [term1, term2] = insert_list(2, :term)
       term2_offered_course =
         insert(:offered_course, term: term2)
         |> Repo.preload(:classes)
 
-      summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: [term2_offered_course]}
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+      summary_data = SummaryHelper.get_term_offered_course_for_user(volunteer)
 
-      assert summary_data == summary_data_response
+      assert summary_data == %{terms: [term1, term2], offered_courses: [term2_offered_course]}
     end
 
     test "when each term has offered_courses" do
+      volunteer = insert(:volunteer)
       [term1, term2] = insert_list(2, :term)
       term1_offered_course =
         insert(:offered_course, term: term1)
@@ -303,34 +282,32 @@ defmodule CoursePlanner.SummaryHelperTest do
       term2_offered_courses = insert_list(4, :offered_course, term: term2)
 
       expected_offered_courses = preload_associations_for_offered_courses([term1_offered_course | term2_offered_courses])
-      summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term1, term2], offered_courses: expected_offered_courses}
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+      summary_data = SummaryHelper.get_term_offered_course_for_user(volunteer)
 
-      assert summary_data == summary_data_response
+      assert summary_data == %{terms: [term1, term2], offered_courses: expected_offered_courses}
     end
 
     test "when term end time is past all it's data will be excluded" do
+      volunteer = insert(:volunteer)
       term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -2))
       term2 = insert(:term)
       insert(:offered_course, term: term1)
       term2_offered_courses = insert_list(4, :offered_course, term: term2)
 
       expected_offered_courses = preload_associations_for_offered_courses(term2_offered_courses)
-      summary_data_response =
-        %{@empty_summary_helper_user_data_response | terms: [term2], offered_courses: expected_offered_courses}
-      summary_data = SummaryHelper.get_term_offered_course_for_user(-1, "Volunteer")
+      summary_data = SummaryHelper.get_term_offered_course_for_user(volunteer)
 
-      assert summary_data == summary_data_response
+      assert summary_data == %{terms: [term2], offered_courses: expected_offered_courses}
     end
 
     test "no data returns when every term's end date is passed" do
+      volunteer = insert(:volunteer)
       term1 = insert(:term, end_date: Timex.shift(Timex.now(), days: -10))
       term2 = insert(:term, end_date: Timex.shift(Timex.now(), days: -20))
       insert_list(6, :offered_course, term: term1)
       insert_list(4, :offered_course, term: term2)
 
-      assert SummaryHelper.get_term_offered_course_for_user(-1, "Coordinator") == @empty_summary_helper_user_data_response
+      assert SummaryHelper.get_term_offered_course_for_user(volunteer) == @empty_summary_helper_user_data_response
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -56,8 +56,8 @@ alias CoursePlanner.{User, Course, OfferedCourse, Class, Attendance, Tasks.Task,
  def term_factory do
    %Term{
      name: sequence(:name, &"term-#{&1}"),
-     start_date: %Ecto.Date{day: 1, month: 1, year: 2017},
-     end_date: %Ecto.Date{day: 1, month: 6, year: 2017},
+     start_date: Timex.shift(Timex.now(), days: -10),
+     end_date:   Timex.shift(Timex.now(), months: 1),
      minimum_teaching_days: 5
    }
  end

--- a/web/models/summary_helper.ex
+++ b/web/models/summary_helper.ex
@@ -1,0 +1,72 @@
+defmodule CoursePlanner.SummaryHelper do
+  @moduledoc """
+    Provides helper functions for the summary page
+  """
+  use CoursePlanner.Web, :model
+
+  alias CoursePlanner.{Repo, Terms.Term, OfferedCourse}
+
+  def get_term_offered_course_for_user(user_id, user_role) do
+    case user_role do
+      "Student" -> get_student_registered_data(user_id)
+      "Teacher" -> get_teacher_registered_data(user_id)
+      "Coordinator" -> get_all_terms_and_offered_courses()
+      "Volunteer" -> get_all_terms_and_offered_courses()
+      _           -> extract_data_from_offered_courses([])
+    end
+  end
+
+  def get_all_terms_and_offered_courses do
+    current_time = Timex.now()
+
+    offered_courses =
+      Repo.all(from oc in OfferedCourse,
+      join: t in assoc(oc, :term),
+      preload: [:course, :classes, term: t],
+      where: t.end_date >= ^current_time)
+
+    terms =
+      Repo.all(from t in Term,
+      where: t.end_date >= ^current_time)
+
+    %{terms: terms, offered_courses: offered_courses}
+  end
+
+  def get_student_registered_data(student_id) do
+    current_time = Timex.now()
+
+    offered_courses =
+      Repo.all(from oc in OfferedCourse,
+        join: s in assoc(oc, :students),
+        join: t in assoc(oc, :term),
+        preload: [:course, :classes, term: t, students: s],
+        where: s.id == ^student_id and t.end_date >= ^current_time)
+
+    extract_data_from_offered_courses(offered_courses)
+  end
+
+  def get_teacher_registered_data(teacher_id) do
+    current_time = Timex.now()
+
+    offered_courses =
+      Repo.all(from oc in OfferedCourse,
+        join: t in assoc(oc, :teachers),
+        join: te in assoc(oc, :term),
+        preload: [:term, :course, :classes, term: te, teachers: t],
+        where: t.id == ^teacher_id and te.end_date >= ^current_time)
+
+    extract_data_from_offered_courses(offered_courses)
+  end
+
+  defp extract_data_from_offered_courses(offered_courses)
+    when is_list(offered_courses) and length(offered_courses) > 0 do
+    terms  =
+      offered_courses
+      |> Enum.map(&(&1.term))
+      |> Enum.uniq()
+
+    %{terms: terms, offered_courses: offered_courses}
+  end
+  defp extract_data_from_offered_courses(_offered_courses), do: %{terms: [], offered_courses: []}
+
+end

--- a/web/models/summary_helper.ex
+++ b/web/models/summary_helper.ex
@@ -69,4 +69,12 @@ defmodule CoursePlanner.SummaryHelper do
   end
   defp extract_data_from_offered_courses(_offered_courses), do: %{terms: [], offered_courses: []}
 
+  def get_next_class(offered_courses)
+    when is_list(offered_courses) and length(offered_courses) > 0 do
+     offered_courses
+       |> Enum.flat_map(&(&1.classes))
+       |> Enum.sort(&(&1.date <= &2.date and &1.starting_at <= &2.starting_at))
+       |> List.first
+  end
+  def get_next_class(_offered_courses), do: nil
 end

--- a/web/models/summary_helper.ex
+++ b/web/models/summary_helper.ex
@@ -6,8 +6,8 @@ defmodule CoursePlanner.SummaryHelper do
 
   alias CoursePlanner.{Repo, Terms.Term, OfferedCourse}
 
-  def get_term_offered_course_for_user(user_id, user_role) do
-    case user_role do
+  def get_term_offered_course_for_user(%{id: user_id, role: role}) do
+    case role do
       "Student" -> get_student_registered_data(user_id)
       "Teacher" -> get_teacher_registered_data(user_id)
       "Coordinator" -> get_all_terms_and_offered_courses()


### PR DESCRIPTION
1. Makes term_factory and affected test independent from hardcoded date
2. Adds functionality for retriving terms and offered_course for users
3. adds a function to get the next_class

Note : the function for getting volunteer tasks is not in this pull request, it will be added after max_volunter pull request gets closed

