### PR TITLE
bug fix : no function clause matching in String.Chars.URI.to_string/1

### DIFF
--- a/lib/course_planner_web/models/setting/settings.ex
+++ b/lib/course_planner_web/models/setting/settings.ex
@@ -29,9 +29,10 @@ defmodule CoursePlanner.Settings do
     system_variable = Repo.get_by(SystemVariable, key: name)
 
     {:ok, parsed_value} =
-      case system_variable do
-        nil -> {:ok, default}
-        _   -> SystemVariable.parse_value(system_variable.value, system_variable.type)
+      cond do
+        system_variable == nil -> {:ok, default}
+        system_variable.value == nil -> {:ok, default}
+        true   -> SystemVariable.parse_value(system_variable.value, system_variable.type)
       end
 
     parsed_value

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -120,7 +120,7 @@ unless Repo.get_by(SystemVariable, key: "PROGRAM_LOGO_URL") do
   |> SystemVariable.changeset(
       %{
         key: "PROGRAM_LOGO_URL",
-        value: "",
+        value: nil,
         type: "url",
         editable: true,
         visible: true,


### PR DESCRIPTION
Settings.get_value function should return nil in case the value saved for the setting is nil so it can use the default value

this is especially important  for url type setting with empty string. we have already save it as nil and now we should consider get_value returning the default value in case system_variable.value is equal to nil