### PR TITLE
Remove fixed MIX_ENV=prod

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: MIX_ENV=prod mix phx.server
+web: mix phx.server

--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
   "logo": "https://course-planner-backend.herokuapp.com/images/logo.svg",
   "success_url": "/",
   "scripts": {
-    "postdeploy": "MIX_ENV=prod POOL_SIZE=2 mix do ecto.migrate, run priv/repo/seeds.exs"
+    "postdeploy": "POOL_SIZE=2 mix do ecto.migrate, run priv/repo/seeds.exs"
   },
   "env": {
     "ENDPOINT_URL_HOST": {

--- a/compile
+++ b/compile
@@ -1,3 +1,3 @@
 cd $phoenix_dir
 npm --prefix ./assets run build
-MIX_ENV=prod mix phx.digest
+mix phx.digest


### PR DESCRIPTION
Set MIX_ENV in Heroku and let the mix commands use the value set in the
environment.
This allows the deploy commands to be used with other environments like
Gigalixir.