### PR TITLE
Remove "NOTIFICATION_JOB_EXECUTED_AT" from the edit page

### DIFF
--- a/lib/course_planner/notifications/notifications.ex
+++ b/lib/course_planner/notifications/notifications.ex
@@ -72,7 +72,7 @@ defmodule CoursePlanner.Notifications do
         type: "utc_datetime",
         required: true,
         visible: false,
-        editable: true
+        editable: false
       })
   end
 
@@ -82,8 +82,7 @@ defmodule CoursePlanner.Notifications do
       %{
         value: DateTime.to_iso8601(timestamp),
         type: "utc_datetime"
-      },
-      :update)
+      })
   end
 
   def create_simple_notification(%{type: type, user: user, path: path, data: data}) do

--- a/lib/course_planner/settings/settings.ex
+++ b/lib/course_planner/settings/settings.ex
@@ -85,7 +85,7 @@ defmodule CoursePlanner.Settings do
       is_nil(found_system_variable) -> :non_existing_resource
       not found_system_variable.editable -> :uneditable_resource
       found_system_variable.editable ->
-        SystemVariable.changeset(found_system_variable, %{"value" => param_value}, :update)
+        SystemVariable.changeset(found_system_variable, %{"value" => param_value}, :user_update)
     end
   end
 

--- a/lib/course_planner/settings/system_variable.ex
+++ b/lib/course_planner/settings/system_variable.ex
@@ -37,7 +37,7 @@ defmodule CoursePlanner.Settings.SystemVariable do
     |> validate_value_type()
   end
 
-  def changeset(struct, params, :update) do
+  def changeset(struct, params, :user_update) do
     target_params =
       [
        :value,

--- a/lib/course_planner_web/controllers/setting_controller.ex
+++ b/lib/course_planner_web/controllers/setting_controller.ex
@@ -63,7 +63,7 @@ defmodule CoursePlannerWeb.SettingController do
           changesets
           |> Enum.sort_by(&(Changeset.get_field(&1, :key)), &<=/2)
           |> Settings.wrap()
-          |> Map.put(:action, :update)
+          |> Map.put(:action, :user_update)
         render(conn, "edit.html", changeset: changeset, title: title)
     end
   end

--- a/lib/course_planner_web/controllers/setting_controller.ex
+++ b/lib/course_planner_web/controllers/setting_controller.ex
@@ -63,7 +63,7 @@ defmodule CoursePlannerWeb.SettingController do
           changesets
           |> Enum.sort_by(&(Changeset.get_field(&1, :key)), &<=/2)
           |> Settings.wrap()
-          |> Map.put(:action, :user_update)
+          |> Map.put(:action, :update)
         render(conn, "edit.html", changeset: changeset, title: title)
     end
   end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -178,7 +178,7 @@ unless Repo.get_by(SystemVariable, key: "NOTIFICATION_JOB_EXECUTED_AT") do
         key: "NOTIFICATION_JOB_EXECUTED_AT",
         value: DateTime.utc_now() |> DateTime.to_iso8601(),
         type: "utc_datetime",
-        editable: true,
+        editable: false,
         visible: false,
         required: true
       })

--- a/test/lib/course_planner/settings/system_variable_test.exs
+++ b/test/lib/course_planner/settings/system_variable_test.exs
@@ -18,7 +18,7 @@ defmodule CoursePlanner.SystemVariableTest do
   end
 
   test "changeset fails for uneditable system variable" do
-    changeset = SystemVariable.changeset(%SystemVariable{}, %{@string_valid_attrs | editable: false}, :update)
+    changeset = SystemVariable.changeset(%SystemVariable{}, %{@string_valid_attrs | editable: false}, :user_update)
     refute changeset.valid?
   end
 


### PR DESCRIPTION
Currently "NOTIFICATION_JOB_EXECUTED_AT" is shown on the edit page and with this PR it will be removed from the edit page