### PR TITLE
Match file upload to Plug.Upload structure

### DIFF
--- a/lib/course_planner_web/controllers/bulk_controller.ex
+++ b/lib/course_planner_web/controllers/bulk_controller.ex
@@ -14,7 +14,7 @@ defmodule CoursePlannerWeb.BulkController do
 
   def create(conn, %{"input" => %{"target" => target,
                                   "title" => title,
-                                  "csv_file" => %{"path" => file_path}}}) do
+                                  "csv_file" => %Plug.Upload{path: file_path}}}) do
     file_path
     |> File.stream!()
     |> handle_csv_file_data(conn, target, title)

--- a/test/controllers/bulk_controller_test.exs
+++ b/test/controllers/bulk_controller_test.exs
@@ -17,19 +17,19 @@ defmodule CoursePlanner.BulkControllerTest do
   defp create_input_params(target, title, csv_data) do
     path = Plug.Upload.random_file!("csv")
     File.write!(path, csv_data)
-    %{"input" => %{"csv_file" => %{"path" => path}, "target" => target, "title" => title}}
+    %{input: %{csv_file: %Plug.Upload{path: path}, target: target, title: title}}
   end
 
   @moduletag user_role: :student
   describe "settings functionality for student user" do
     test "does not render new page", %{conn: conn} do
-      conn = get conn, bulk_path(conn, :new, target: "user", title: "Bulk Users")
+      conn = get conn, bulk_path(conn, :new), target: "user", title: "Bulk Users"
       assert html_response(conn, 403)
     end
 
     test "does not create bulk request for student user", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,Anickname,a@a.com,Student")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 403)
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")
     end
@@ -38,13 +38,13 @@ defmodule CoursePlanner.BulkControllerTest do
   @moduletag user_role: :teacher
   describe "settings functionality for teacher user" do
     test "does not render new page", %{conn: conn} do
-      conn = get conn, bulk_path(conn, :new, target: "user", title: "Bulk Users")
+      conn = get conn, bulk_path(conn, :new), target: "user", title: "Bulk Users"
       html_response(conn, 403)
     end
 
     test "does not create bulk request for teacher user", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,Anickname,a@a.com,student")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 403)
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")
     end
@@ -53,13 +53,13 @@ defmodule CoursePlanner.BulkControllerTest do
   @moduletag user_role: :volunteer
   describe "settings functionality for volunteer user" do
     test "does not render new page", %{conn: conn} do
-      conn = get conn, bulk_path(conn, :new, target: "user", title: "Bulk Users")
+      conn = get conn, bulk_path(conn, :new), target: "user", title: "Bulk Users"
       assert html_response(conn, 403)
     end
 
     test "does not create bulk request for volunteer user", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,Anickname,a@a.com,Student")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 403)
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")
     end
@@ -68,14 +68,14 @@ defmodule CoursePlanner.BulkControllerTest do
   @moduletag user_role: :coordinator
   describe "settings functionality for coordinator user" do
     test "render new page", %{conn: conn} do
-      conn = get conn, bulk_path(conn, :new, target: "user", title: "Bulk Users")
+      conn = get conn, bulk_path(conn, :new), target: "user", title: "Bulk Users"
       assert html_response(conn, 200) =~ "Bulk Users"
     end
 
     @tag user_role: :coordinator
     test "creates bulk request with one row of data", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,Anickname,a@a.com,Student")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert redirected_to(conn) == user_path(conn, :index)
       assert get_flash(conn, "info") == "All users are created and notified by"
       assert Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")
@@ -89,7 +89,7 @@ defmodule CoursePlanner.BulkControllerTest do
            Cname,CFamile,Cnickname,c@c.com,Volunteer
            Dname,DFamile,Dnickname,d@d.com,Coordinator
         """)
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert redirected_to(conn) == user_path(conn, :index)
       assert get_flash(conn, "info") == "All users are created and notified by"
       assert Repo.get_by(User, email: "a@a.com")
@@ -100,13 +100,13 @@ defmodule CoursePlanner.BulkControllerTest do
 
     test "does not create bulk request if input file is missing", %{conn: conn} do
       params = %{"input" => %{"target" => "user", "title" => "user bulk creation"}}
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 200) =~ "You have to select a file"
     end
 
     test "does not create bulk request if input file is empty", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 200) =~ "Input can not be empty"
     end
 
@@ -117,7 +117,7 @@ defmodule CoursePlanner.BulkControllerTest do
 
 
         """)
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert get_flash(conn, "error") == "Row has length 1 - expected length 5 on line 1"
     end
 
@@ -129,7 +129,7 @@ defmodule CoursePlanner.BulkControllerTest do
           Cname,CFamile,Cnickname,,Volunteer
           Dname,DFamile,Dnickname,d@d.com,Coordinator
         """)
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert get_flash(conn, "error") == "email can't be blank"
       refute Repo.get_by(User, email: "a@a.com")
       refute Repo.get_by(User, email: "b@b.com")
@@ -145,7 +145,7 @@ defmodule CoursePlanner.BulkControllerTest do
          Cname,CFamile,Cnickname,Volunteer
          Dname,DFamile,Dnickname,d@d.com,Coordinator
       """)
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert get_flash(conn, "error") == "Row has length 4 - expected length 5 on line 3"
       refute Repo.get_by(User, email: "a@a.com")
       refute Repo.get_by(User, email: "b@b.com")
@@ -155,21 +155,21 @@ defmodule CoursePlanner.BulkControllerTest do
 
     test "does not create bulk request if input file does not have the correct format", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,,Anickname,a@a.com\nBname")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 200) =~ "Row has length 1 - expected length 5 on line 2"
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", email: "a@a.com", role: "Student")
     end
 
     test "does not create bulk request if input fields are not enough", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,Anickname,a@a.com")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 200) =~ "Row has length 4 - expected length 5 on line 1"
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")
     end
 
     test "does not create bulk request if role is unknown", %{conn: conn} do
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,Anickname,a@a.com,unknown")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 200)
       assert get_flash(conn, "error") == "role is invalid"
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")
@@ -178,7 +178,7 @@ defmodule CoursePlanner.BulkControllerTest do
     test "does not create bulk request if email is already taken", %{conn: conn} do
       insert(:student, email: "a@a.com")
       params = create_input_params("user", "user bulk creation", "Aname,AFamile,Anickname,a@a.com,Student")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 200)
       assert get_flash(conn, "error") == "email has already been taken"
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")
@@ -186,7 +186,7 @@ defmodule CoursePlanner.BulkControllerTest do
 
     test "returning error if no action is implemented for the requested target", %{conn: conn} do
       params = create_input_params("invalid target", "user bulk creation", "Aname,AFamile,Anickname,a@a.com,Student")
-      conn = post conn, bulk_path(conn, :create, params)
+      conn = post conn, bulk_path(conn, :create), params
       assert html_response(conn, 200)
       assert get_flash(conn, "error") == "Something went wrong"
       refute Repo.get_by(User, name: "Aname", family_name: "AFamile", role: "Student")


### PR DESCRIPTION
Before we always got an error that the file was not given because the
parameters were not matching.