### PR TITLE
Fix Attendance missing notification

### DIFF
--- a/lib/course_planner/notifications/notification.ex
+++ b/lib/course_planner/notifications/notification.ex
@@ -16,7 +16,7 @@
 
   @types ~w(user_modified course_updated course_deleted
            term_updated term_deleted class_subscribed
-           class_updated class_deleted)
+           class_updated class_deleted attendance_missing)
 
   @doc """
   Builds a changeset based on the `struct` and `params`.

--- a/lib/course_planner_web/templates/email/attendance_missing.html.eex
+++ b/lib/course_planner_web/templates/email/attendance_missing.html.eex
@@ -1,6 +1,6 @@
 <div>
   <h2>Dear <%= @name %>,</h2>
-  <h2>The attendances are not completely filled for <%= @data.offered_course_name %></h2>
+  <h2>The attendances are not completely filled for <%= @data["offered_course_name"] %></h2>
   <h3>use the following link to update the attendances <%= link "here: ", to: @path%></h3>
 
   <h3>This is an automatically generated email, please do not reply</h3>

--- a/lib/course_planner_web/templates/email/summary.html.eex
+++ b/lib/course_planner_web/templates/email/summary.html.eex
@@ -1,6 +1,8 @@
 <h1>Here's your activity summary:</h1>
 <ul>
   <%= for notification <- @notifications do %>
-    <li><%= render @view_module, @params[notification.type].template, assigns |> Map.put(:path, notification.resource_path) %></li>
+    <% template = @params[notification.type].template %>
+    <% attributes = %{path: notification.resource_path, data: notification.data} %>
+    <li><%= render @view_module, template, Map.merge(assigns, attributes) %></li>
   <% end %>
 </ul>

--- a/test/lib/course_planner/mailer/user_email_test.exs
+++ b/test/lib/course_planner/mailer/user_email_test.exs
@@ -56,13 +56,20 @@ defmodule CoursePlanner.UserEmailTest do
 
     {type, subject} = {:attendance_missing, "One or more attendances are not filled"}
 
+    notification =
+      Notifications.new()
+      |> Notifications.to(@valid_user)
+      |> Notifications.type(type)
+      |> Notifications.resource_path(path)
+      |> Notifications.add_data(data)
+      |> Notifications.Notification.changeset()
+      |> CoursePlanner.Repo.insert!
+
     email =
-    Notifications.new()
-    |> Notifications.to(@valid_user)
-    |> Notifications.type(type)
-    |> Notifications.resource_path(path)
-    |> Notifications.add_data(data)
-    |> UserEmail.build_email()
+      Notifications.Notification
+      |> CoursePlanner.Repo.get(notification.id)
+      |> CoursePlanner.Repo.preload(:user)
+      |> UserEmail.build_email()
 
     assert email.html_body =~ path
     assert email.html_body =~ data.offered_course_name

--- a/test/lib/course_planner/notifications/server_test.exs
+++ b/test/lib/course_planner/notifications/server_test.exs
@@ -25,7 +25,7 @@ defmodule CoursePlanner.Notifier.ServerTest do
     user = insert(:user)
     insert(:notification, %{user_id: user.id})
     insert(:notification, %{user_id: user.id})
-    insert(:notification, %{user_id: user.id})
+    insert(:notification, %{user_id: user.id, type: "attendance_missing", data: %{offered_course_name: "Bah"}})
 
     saved_user = Repo.get(User, user.id) |> Repo.preload(:notifications)
 


### PR DESCRIPTION
- Add `attendance_missing` to allowed notification type
- Add notification data to the email summary rendering
- Change access of json notification data from atom to string