### PR TITLE
Introduced restriction on edit and update for teacher

### DIFF
--- a/lib/course_planner/accounts/teachers.ex
+++ b/lib/course_planner/accounts/teachers.ex
@@ -42,4 +42,9 @@ defmodule CoursePlanner.Accounts.Teachers do
       where: oct.teacher_id == ^teacher_id,
       order_by: [desc: t.start_date])
   end
+
+  def can_update_offered_course?(user, offered_course) do
+    offered_course.teachers
+    |> Enum.any?(fn(teacher) -> teacher.id ==  user.id end)
+  end
 end

--- a/lib/course_planner/courses/offered_courses.ex
+++ b/lib/course_planner/courses/offered_courses.ex
@@ -109,9 +109,4 @@ defmodule CoursePlanner.Courses.OfferedCourses do
 
     {:ok, offered_course, changeset}
   end
-
-  def can_teacher_edit_and_update_offered_course?(user, offered_course) do
-    offered_course.teachers
-    |> Enum.any?(fn(teacher) -> teacher.id ==  user.id end)
-  end
 end

--- a/lib/course_planner/courses/offered_courses.ex
+++ b/lib/course_planner/courses/offered_courses.ex
@@ -99,4 +99,19 @@ defmodule CoursePlanner.Courses.OfferedCourses do
          |> @notifier.notify_later()
        end)
   end
+
+  def load_offered_course_for_edit(id) do
+    offered_course =
+      OfferedCourse
+      |> Repo.get!(id)
+      |> Repo.preload([:term, :course, :students, :teachers])
+    changeset = OfferedCourse.changeset(offered_course)
+
+    {:ok, offered_course, changeset}
+  end
+
+  def can_teacher_edit_and_update_offered_course?(user, offered_course) do
+    offered_course.teachers
+    |> Enum.any?(fn(teacher) -> teacher.id ==  user.id end)
+  end
 end

--- a/lib/course_planner_web/templates/offered_course/index.html.eex
+++ b/lib/course_planner_web/templates/offered_course/index.html.eex
@@ -73,6 +73,11 @@
                   """] %>
                 </li>
               <% end %>
+              <%= if @conn.assigns.current_user.role == "Teacher" do %>
+                <li class="mdl-menu__item">
+                  <%= link "Edit", to: offered_course_path(@conn, :edit, offered_course) %>
+                </li>
+              <% end %>
             </ul>
           </td>
         </tr>

--- a/lib/course_planner_web/templates/offered_course/teacher_edit.html.eex
+++ b/lib/course_planner_web/templates/offered_course/teacher_edit.html.eex
@@ -3,9 +3,5 @@
                           changeset: @changeset,
                           action: offered_course_path(@conn, :update, @offered_course),
                           conn: @conn,
-                          offered_course: @offered_course,
-                          next_classes: @next_classes,
-                          past_classes: @past_classes,
-                          user_role: @user_role
-
+                          offered_course: @offered_course
   %>

--- a/lib/course_planner_web/templates/offered_course/teacher_edit.html.eex
+++ b/lib/course_planner_web/templates/offered_course/teacher_edit.html.eex
@@ -1,0 +1,11 @@
+
+  <%= render "teacher_edit_form.html", title: "Edit course",
+                          changeset: @changeset,
+                          action: offered_course_path(@conn, :update, @offered_course),
+                          conn: @conn,
+                          offered_course: @offered_course,
+                          next_classes: @next_classes,
+                          past_classes: @past_classes,
+                          user_role: @user_role
+
+  %>

--- a/lib/course_planner_web/templates/offered_course/teacher_edit_form.html.eex
+++ b/lib/course_planner_web/templates/offered_course/teacher_edit_form.html.eex
@@ -1,0 +1,83 @@
+  <div class="row">
+    <div class="
+      col-xs-12
+      col-sm-offset-1 col-sm-10
+      col-md-offset-2 col-md-8
+      col-lg-offset-2 col-lg-8
+    ">
+      <div class="row middle-xs page-header">
+        <div class="col-xs-6 col-sm-9 col-md-10 page-title">
+          <%= Enum.join [@offered_course.course.name, @offered_course.term.name], " - " %>
+        </div>
+        <%= if @user_role == "Coordinator" do %>
+          <div class="col-xs-6 col-sm-3 col-md-2">
+            <%= link "Edit", to: offered_course_path(@conn, :edit, @offered_course),
+                             class: "mdl-button mdl-js-button mdl-button--raised"
+            %>
+          </div>
+        <% end %>
+      </div>
+
+      <%= form_for @changeset, @action, fn f -> %>
+        <%= CoursePlannerWeb.SharedView.card @title do %>
+          <%= CoursePlannerWeb.SharedView.card_content do %>
+            <%= if @changeset.action do %>
+              <div class="form-error">
+                <p>Oops, something went wrong! Please check the errors below.</p>
+              </div>
+            <% end %>
+            <%= CoursePlannerWeb.SharedView.form_textarea f, :syllabus %>
+          <% end %>
+          <%= CoursePlannerWeb.SharedView.card_actions do %>
+            <div class="row row--vspace">
+              <div class="col-xs-12 col-md-3 col-md-offset-9">
+                <%= CoursePlannerWeb.SharedView.form_submit f, "Send" %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+
+        <%= if length(@next_classes) > 0 do %>
+          <div class="row middle-xs page-header">
+            <div class="col-xs-12 page-title page-title--small">
+              Next Classes
+            </div>
+          </div>
+          <%= CoursePlannerWeb.SharedView.class_list @next_classes, empty_text: "This course has no classes yet",
+                                                                 show_attendances: @user_role === "Student"
+          %>
+        <% end %>
+
+        <%= if length(@past_classes) > 0 do %>
+          <div class="row middle-xs page-header">
+            <div class="col-xs-12 page-title page-title--small">
+              Past Classes
+            </div>
+          </div>
+          <%= CoursePlannerWeb.SharedView.class_list @past_classes, empty_text: "This course has no classes yet",
+                                                                 show_attendances: @user_role === "Student"
+          %>
+        <% end %>
+
+        <div class="row middle-xs page-header">
+          <div class="col-xs-12 page-title page-title--small">
+            Teachers
+          </div>
+        </div>
+        <%= CoursePlannerWeb.SharedView.user_list @conn.assigns.current_user, @offered_course.teachers, empty_text: "This course has no teachers yet" %>
+
+        <div class="row middle-xs page-header">
+          <div class="col-xs-12 page-title page-title--small">
+            <%= if @user_role == "Student" do %>
+              Classmates
+            <% else %>
+              Students
+            <% end %>
+          </div>
+        </div>
+        <%= CoursePlannerWeb.SharedView.user_list @conn.assigns.current_user, @offered_course.students, empty_text: "This course has no students yet" %>
+
+      </div>
+    </div>
+  </div>

--- a/lib/course_planner_web/templates/offered_course/teacher_edit_form.html.eex
+++ b/lib/course_planner_web/templates/offered_course/teacher_edit_form.html.eex
@@ -31,38 +31,5 @@
         <% end %>
       <% end %>
 
-        <%= if length(@next_classes) > 0 do %>
-          <div class="row middle-xs page-header">
-            <div class="col-xs-12 page-title page-title--small">
-              Next Classes
-            </div>
-          </div>
-          <%= CoursePlannerWeb.SharedView.class_list @next_classes, empty_text: "This course has no classes yet" %>
-        <% end %>
-
-        <%= if length(@past_classes) > 0 do %>
-          <div class="row middle-xs page-header">
-            <div class="col-xs-12 page-title page-title--small">
-              Past Classes
-            </div>
-          </div>
-          <%= CoursePlannerWeb.SharedView.class_list @past_classes, empty_text: "This course has no classes yet" %>
-        <% end %>
-
-        <div class="row middle-xs page-header">
-          <div class="col-xs-12 page-title page-title--small">
-            Teachers
-          </div>
-        </div>
-        <%= CoursePlannerWeb.SharedView.user_list @conn.assigns.current_user, @offered_course.teachers, empty_text: "This course has no teachers yet" %>
-
-        <div class="row middle-xs page-header">
-          <div class="col-xs-12 page-title page-title--small">
-            Students
-          </div>
-        </div>
-        <%= CoursePlannerWeb.SharedView.user_list @conn.assigns.current_user, @offered_course.students, empty_text: "This course has no students yet" %>
-
       </div>
     </div>
-  </div>

--- a/lib/course_planner_web/templates/offered_course/teacher_edit_form.html.eex
+++ b/lib/course_planner_web/templates/offered_course/teacher_edit_form.html.eex
@@ -9,13 +9,6 @@
         <div class="col-xs-6 col-sm-9 col-md-10 page-title">
           <%= Enum.join [@offered_course.course.name, @offered_course.term.name], " - " %>
         </div>
-        <%= if @user_role == "Coordinator" do %>
-          <div class="col-xs-6 col-sm-3 col-md-2">
-            <%= link "Edit", to: offered_course_path(@conn, :edit, @offered_course),
-                             class: "mdl-button mdl-js-button mdl-button--raised"
-            %>
-          </div>
-        <% end %>
       </div>
 
       <%= form_for @changeset, @action, fn f -> %>
@@ -44,9 +37,7 @@
               Next Classes
             </div>
           </div>
-          <%= CoursePlannerWeb.SharedView.class_list @next_classes, empty_text: "This course has no classes yet",
-                                                                 show_attendances: @user_role === "Student"
-          %>
+          <%= CoursePlannerWeb.SharedView.class_list @next_classes, empty_text: "This course has no classes yet" %>
         <% end %>
 
         <%= if length(@past_classes) > 0 do %>
@@ -55,9 +46,7 @@
               Past Classes
             </div>
           </div>
-          <%= CoursePlannerWeb.SharedView.class_list @past_classes, empty_text: "This course has no classes yet",
-                                                                 show_attendances: @user_role === "Student"
-          %>
+          <%= CoursePlannerWeb.SharedView.class_list @past_classes, empty_text: "This course has no classes yet" %>
         <% end %>
 
         <div class="row middle-xs page-header">
@@ -69,11 +58,7 @@
 
         <div class="row middle-xs page-header">
           <div class="col-xs-12 page-title page-title--small">
-            <%= if @user_role == "Student" do %>
-              Classmates
-            <% else %>
-              Students
-            <% end %>
+            Students
           </div>
         </div>
         <%= CoursePlannerWeb.SharedView.user_list @conn.assigns.current_user, @offered_course.students, empty_text: "This course has no students yet" %>

--- a/test/controllers/offered_course_controller_test.exs
+++ b/test/controllers/offered_course_controller_test.exs
@@ -256,6 +256,15 @@ defmodule CoursePlanner.OfferedCourseControllerTest do
   end
 
   @tag user_role: :teacher
+  test "teacher can not update if syllabus is empty", %{conn: conn} do
+    teacher = conn.assigns.current_user
+    offered_course = insert(:offered_course, teachers: [teacher])
+    params = %{syllabus: ""}
+    conn = put conn, offered_course_path(conn, :update, offered_course), offered_course: params
+    assert html_response(conn, 200) =~ "Edit course"
+  end
+
+  @tag user_role: :teacher
   test "teacher can list their offered courses", %{conn: conn} do
     conn = get conn, offered_course_path(conn, :index)
     assert html_response(conn, 200)


### PR DESCRIPTION
1 - add edit button to offered_courses index page for teacher
2 - teacher can render only edit page for offered_courses assigned to her
3 - teacher can update only Syllabus of offered courses assigned to her

detail : https://app.nostromo.io/work/course-planner/teacher-can-edit-the-course-by-modifying-the-link?e21vZHVsZTp3b3JrLHByb2plY3Q6NjM2OCxjYXJkOjk2Mjg3LGNhcmRfdGl0bGU6dGVhY2hlci1jYW4tZWRpdC10aGUtY291cnNlLWJ5LW1vZGlmeWluZy10aGUtbGlua30=