### PR TITLE
show newline in description and comment fields

### DIFF
--- a/lib/course_planner_web/templates/about/show.html.eex
+++ b/lib/course_planner_web/templates/about/show.html.eex
@@ -21,7 +21,7 @@
                   <div class="detail">
                     <div class="detail__name">Address</div>
                     <div class="detail__value">
-                      <%= @program_data.address %>
+                      <%= CoursePlannerWeb.SharedView.format_text_to_html(@program_data.address) %>
                     </div>
                   </div>
                 <% end%>
@@ -39,7 +39,7 @@
                   <div class="detail">
                     <div class="detail__name">Phone number</div>
                     <div class="detail__value">
-                      <%= @program_data.phone %>
+                      <%= CoursePlannerWeb.SharedView.format_text_to_html(@program_data.phone) %>
                     </div>
                   </div>
                 <% end %>
@@ -48,7 +48,7 @@
                   <div class="detail">
                     <div class="detail__name">Website</div>
                     <div class="detail__value">
-                      <%= @program_data.website %>
+                      <%= CoursePlannerWeb.SharedView.format_text_to_html(@program_data.website) %>
                     </div>
                   </div>
                 <% end %>
@@ -57,7 +57,7 @@
                   <div class="detail">
                     <div class="detail__name">Description</div>
                     <div class="detail__value">
-                      <%= @program_data.description %>
+                      <%= CoursePlannerWeb.SharedView.format_text_to_html(@program_data.description) %>
                     </div>
                   </div>
                 <% end %>
@@ -66,7 +66,7 @@
                   <div class="detail">
                     <div class="detail__name">Information</div>
                     <div class="detail__value">
-                      <%= @program_data.information %>
+                      <%= CoursePlannerWeb.SharedView.format_text_to_html(@program_data.information) %>
                     </div>
                   </div>
                 <% end %>

--- a/lib/course_planner_web/templates/offered_course/show.html.eex
+++ b/lib/course_planner_web/templates/offered_course/show.html.eex
@@ -23,7 +23,7 @@
         <%= CoursePlannerWeb.SharedView.card "Syllabus", highlighted_title: true do %>
           <%= CoursePlannerWeb.SharedView.card_content do %>
             <div class="card-text">
-              <%= @offered_course.syllabus %>
+              <%= CoursePlannerWeb.SharedView.format_text_to_html(@offered_course.syllabus) %>
             </div>
           <% end %>
         <% end %>

--- a/lib/course_planner_web/templates/student/show.html.eex
+++ b/lib/course_planner_web/templates/student/show.html.eex
@@ -69,7 +69,7 @@
                 <div class="detail">
                   <div class="detail__name">Comments</div>
                   <div class="detail__value">
-                    <%= @student.comments %>
+                    <%= CoursePlannerWeb.SharedView.format_text_to_html(@student.comments) %>
                   </div>
                 </div>
                 <div class="detail">

--- a/lib/course_planner_web/templates/task/show.html.eex
+++ b/lib/course_planner_web/templates/task/show.html.eex
@@ -53,7 +53,7 @@
                 <div class="detail">
                   <div class="detail__name">Description</div>
                   <div class="detail__value">
-                    <%= @task.description %>
+                    <%= CoursePlannerWeb.SharedView.format_text_to_html(@task.description) %>
                   </div>
                 </div>
               </div>

--- a/lib/course_planner_web/views/shared_view.ex
+++ b/lib/course_planner_web/views/shared_view.ex
@@ -8,7 +8,7 @@ defmodule CoursePlannerWeb.SharedView do
   # helpers
 
   def format_text_to_html(text) do
-    Format.text_to_html(text)
+    text && Format.text_to_html(text)
   end
 
   def path_exact_match(conn, path) do

--- a/lib/course_planner_web/views/shared_view.ex
+++ b/lib/course_planner_web/views/shared_view.ex
@@ -3,10 +3,12 @@ defmodule CoursePlannerWeb.SharedView do
   use CoursePlannerWeb, :view
 
   alias CoursePlanner.Settings
+  alias Phoenix.HTML.Format
 
   # helpers
+
   def format_text_to_html(text) do
-    Phoenix.HTML.Format.text_to_html(text)
+    Format.text_to_html(text)
   end
 
   def path_exact_match(conn, path) do

--- a/lib/course_planner_web/views/shared_view.ex
+++ b/lib/course_planner_web/views/shared_view.ex
@@ -5,6 +5,9 @@ defmodule CoursePlannerWeb.SharedView do
   alias CoursePlanner.Settings
 
   # helpers
+  def format_text_to_html(text) do
+    Phoenix.HTML.Format.text_to_html(text)
+  end
 
   def path_exact_match(conn, path) do
     conn.request_path == path


### PR DESCRIPTION
description : https://app.nostromo.io/work/course-planner/text-stylings-like-newline-is-ignored-in-text-and-string-fields?e21vZHVsZTp3b3JrLHByb2plY3Q6NjM2OCxjYXJkOjk2NDYzLGNhcmRfdGl0bGU6dGV4dC1zdHlsaW5ncy1saWtlLW5ld2xpbmUtaXMtaWdub3JlZC1pbi10ZXh0LWFuZC1zdHJpbmctZmllbGRzfQ==