### PR TITLE
Organizes class index page

### DIFF
--- a/lib/course_planner/classes/classes.ex
+++ b/lib/course_planner/classes/classes.ex
@@ -69,7 +69,7 @@ defmodule CoursePlanner.Classes do
     Repo.all(from c in Class, where: c.offered_course_id == ^offered_course_id)
   end
 
- def classes_with_attendances(offered_course_id, user_id) do
+  def classes_with_attendances(offered_course_id, user_id) do
     query = from c in Class,
       left_join: a in assoc(c, :attendances), on: a.student_id == ^user_id,
       where: c.offered_course_id == ^offered_course_id,

--- a/lib/course_planner_web/controllers/class_controller.ex
+++ b/lib/course_planner_web/controllers/class_controller.ex
@@ -2,17 +2,21 @@ defmodule CoursePlannerWeb.ClassController do
   @moduledoc false
   use CoursePlannerWeb, :controller
 
-  alias CoursePlanner.{Classes.Class, Classes, Attendances}
+  alias CoursePlanner.{Classes.Class, Classes, Attendances, Terms.Term}
 
   import Canary.Plugs
   plug :authorize_controller
 
   def index(conn, _params) do
-    classes =
-      Class
-      |> Repo.all()
-      |> Repo.preload([:offered_course, offered_course: :term, offered_course: :course])
-    render(conn, "index.html", classes: classes)
+    query = from t in Term,
+    join: oc in assoc(t, :offered_courses),
+    join: c in assoc(oc, :classes),
+    preload: [offered_courses: :course, offered_courses: {oc, classes: c}],
+    order_by: [asc: t.start_date, asc: c.date, asc: c.starting_at, asc: c.finishes_at]
+
+    terms = Repo.all(query)
+
+    render(conn, "index.html", terms: terms)
   end
 
   def new(conn, _params) do

--- a/lib/course_planner_web/controllers/class_controller.ex
+++ b/lib/course_planner_web/controllers/class_controller.ex
@@ -10,9 +10,10 @@ defmodule CoursePlannerWeb.ClassController do
   def index(conn, _params) do
     query = from t in Term,
     join: oc in assoc(t, :offered_courses),
+    join: co in assoc(oc, :course),
     join: c in assoc(oc, :classes),
-    preload: [offered_courses: :course, offered_courses: {oc, classes: c}],
-    order_by: [asc: t.start_date, asc: c.date, asc: c.starting_at, asc: c.finishes_at]
+    preload: [offered_courses: {oc, classes: c, course: co}],
+    order_by: [asc: t.start_date, asc: co.name, asc: c.date, asc: c.starting_at, asc: c.finishes_at]
 
     terms = Repo.all(query)
 

--- a/lib/course_planner_web/templates/class/index.html.eex
+++ b/lib/course_planner_web/templates/class/index.html.eex
@@ -1,4 +1,3 @@
-
   <div class="row middle-xs page-header">
     <div class="col-xs-6 col-sm-9 col-md-10 page-title">
       Classes
@@ -8,79 +7,93 @@
     </div>
   </div>
 
-  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp page">
-    <thead>
-      <tr>
-        <th class="mdl-data-table__cell--non-numeric">Term</th>
-        <th class="mdl-data-table__cell--non-numeric">Course type</th>
-        <th>Classroom</th>
-        <th>Class date</th>
-        <th>Starting at</th>
-        <th>Finishes at</th>
-        <%= if @conn.assigns.current_user.role == "Coordinator" do %>
-          <th></th>
+  <%= for term <- @terms do %>
+    <div class="page">
+      <%= CoursePlannerWeb.SharedView.card do %>
+        <%= CoursePlannerWeb.SharedView.card_content vpadding: true do %>
+          <div class="row row--hspace row--vspace middle-xs">
+            <div class="col-xs-9">
+              <div class="row middle-xs page-header">
+                <div class="col-xs-6 col-sm-9 col-md-10 page-title">
+                  <%= term.name %>
+                </div>
+              </div>
+            </div>
+            <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp page">
+              <thead>
+                <tr>
+                  <th>Class date</th>
+                  <th>Starting at</th>
+                  <th>Finishes at</th>
+                  <th>Classroom</th>
+                  <%= if @conn.assigns.current_user.role == "Coordinator" do %>
+                    <th></th>
+                  <% end %>
+                </tr>
+              </thead>
+              <tbody>
+                <%= for offered_course <- term.offered_courses do %>
+                  <td class="mdl-data-table__cell--non-numeric">
+                    <b><%= offered_course.course.name %></b>
+                  </td>
+                  <%= Enum.with_index(offered_course.classes) |> Enum.map(fn {class,index} -> %>
+                    <tr>
+                      <td>
+                        <%= class.date %>
+                      </td>
+                      <td>
+                        <%= class.date
+                            |> Ecto.DateTime.from_date_and_time(class.starting_at)
+                            |> Timex.format!("{h24}:{m}") %>
+                      </td>
+                      <td>
+                        <%= class.date
+                            |> Ecto.DateTime.from_date_and_time(class.finishes_at)
+                            |> Timex.format!("{h24}:{m}") %>
+                      </td>
+                      <td>
+                        <%= class.classroom %>
+                      </td>
+                      <%= if @conn.assigns.current_user.role == "Coordinator" do %>
+                        <td>
+                          <button id="tr_menu_<%= class.id %>"
+                                  class="mdl-button mdl-js-button mdl-button--icon"
+                          >
+                            <i class="material-icons">more_vert</i>
+                          </button>
+                          <ul
+                            class="
+                              mdl-menu mdl-js-menu
+                              <%=
+                                if index > 10 and index > length(@classes)-4 do
+                                  'mdl-menu--top-right'
+                                else
+                                  'mdl-menu--bottom-right'
+                                end
+                              %>
+                            "
+                            for="tr_menu_<%= class.id %>"
+                          >
+                            <li class="mdl-menu__item">
+                              <%= link "Edit", to: class_path(@conn, :edit, class) %>
+                            </li>
+                            <li class="mdl-menu__item">
+                              <%= link "Delete", to: class_path(@conn, :delete, class), method: :delete,
+                                data: [confirm: """
+                                Are you sure?
+                                All the attendances of that class will be removed.
+                                """] %>
+                            </li>
+                          </ul>
+                        </td>
+                      <% end %>
+                    </tr>
+                  <% end) %>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
         <% end %>
-      </tr>
-    </thead>
-    <tbody>
-      <%= Enum.with_index(@classes) |> Enum.map(fn {class,index} -> %>
-        <tr>
-          <td class="mdl-data-table__cell--non-numeric">
-            <%= class.offered_course.term.name %>
-          </td>
-          <td class="mdl-data-table__cell--non-numeric">
-            <%= class.offered_course.course.name %>
-          </td>
-          <td>
-            <%= class.classroom %>
-          </td>
-          <td>
-            <%= class.date %>
-          </td>
-          <td>
-            <%= class.date
-                |> Ecto.DateTime.from_date_and_time(class.starting_at)
-                |> Timex.format!("{h24}:{m}") %>
-          </td>
-          <td>
-            <%= class.date
-                |> Ecto.DateTime.from_date_and_time(class.finishes_at)
-                |> Timex.format!("{h24}:{m}") %>
-          </td>
-          <%= if @conn.assigns.current_user.role == "Coordinator" do %>
-            <td>
-              <button id="tr_menu_<%= class.id %>"
-                      class="mdl-button mdl-js-button mdl-button--icon"
-              >
-                <i class="material-icons">more_vert</i>
-              </button>
-              <ul
-                class="
-                  mdl-menu mdl-js-menu
-                  <%=
-                    if index > 10 and index > length(@classes)-4 do
-                      'mdl-menu--top-right'
-                    else
-                      'mdl-menu--bottom-right'
-                    end
-                  %>
-                "
-                for="tr_menu_<%= class.id %>"
-              >
-                <li class="mdl-menu__item">
-                  <%= link "Edit", to: class_path(@conn, :edit, class) %>
-                </li>
-                <li class="mdl-menu__item">
-                  <%= link "Delete", to: class_path(@conn, :delete, class), method: :delete,
-                    data: [confirm: """
-                    Are you sure?
-                    All the attendances of that class will be removed.
-                    """] %>
-                </li>
-              </ul>
-            </td>
-          <% end %>
-        </tr>
-      <% end) %>
-    </tbody>
-  </table>
+      <% end %>
+    </div>
+  <% end %>

--- a/lib/course_planner_web/templates/class/index.html.eex
+++ b/lib/course_planner_web/templates/class/index.html.eex
@@ -8,92 +8,86 @@
   </div>
 
   <%= for term <- @terms do %>
-    <div class="page">
-      <%= CoursePlannerWeb.SharedView.card do %>
-        <%= CoursePlannerWeb.SharedView.card_content vpadding: true do %>
-          <div class="row row--hspace row--vspace middle-xs">
-            <div class="col-xs-9">
-              <div class="row middle-xs page-header">
-                <div class="col-xs-6 col-sm-9 col-md-10 page-title">
-                  <%= term.name %>
-                </div>
-              </div>
-            </div>
-            <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp page">
-              <thead>
-                <tr>
-                  <th>Class date</th>
-                  <th>Starting at</th>
-                  <th>Finishes at</th>
-                  <th>Classroom</th>
-                  <%= if @conn.assigns.current_user.role == "Coordinator" do %>
-                    <th></th>
-                  <% end %>
-                </tr>
-              </thead>
-              <tbody>
-                <%= for offered_course <- term.offered_courses do %>
-                  <td class="mdl-data-table__cell--non-numeric">
-                    <b><%= offered_course.course.name %></b>
-                  </td>
-                  <%= Enum.with_index(offered_course.classes) |> Enum.map(fn {class,index} -> %>
-                    <tr>
-                      <td>
-                        <%= class.date %>
-                      </td>
-                      <td>
-                        <%= class.date
-                            |> Ecto.DateTime.from_date_and_time(class.starting_at)
-                            |> Timex.format!("{h24}:{m}") %>
-                      </td>
-                      <td>
-                        <%= class.date
-                            |> Ecto.DateTime.from_date_and_time(class.finishes_at)
-                            |> Timex.format!("{h24}:{m}") %>
-                      </td>
-                      <td>
-                        <%= class.classroom %>
-                      </td>
-                      <%= if @conn.assigns.current_user.role == "Coordinator" do %>
-                        <td>
-                          <button id="tr_menu_<%= class.id %>"
-                                  class="mdl-button mdl-js-button mdl-button--icon"
-                          >
-                            <i class="material-icons">more_vert</i>
-                          </button>
-                          <ul
-                            class="
-                              mdl-menu mdl-js-menu
-                              <%=
-                                if index > 10 and index > length(@classes)-4 do
-                                  'mdl-menu--top-right'
-                                else
-                                  'mdl-menu--bottom-right'
-                                end
-                              %>
-                            "
-                            for="tr_menu_<%= class.id %>"
-                          >
-                            <li class="mdl-menu__item">
-                              <%= link "Edit", to: class_path(@conn, :edit, class) %>
-                            </li>
-                            <li class="mdl-menu__item">
-                              <%= link "Delete", to: class_path(@conn, :delete, class), method: :delete,
-                                data: [confirm: """
-                                Are you sure?
-                                All the attendances of that class will be removed.
-                                """] %>
-                            </li>
-                          </ul>
-                        </td>
-                      <% end %>
-                    </tr>
-                  <% end) %>
-                <% end %>
-              </tbody>
-            </table>
+    <div class="row row--hspace row--vspace middle-xs">
+      <div class="col-xs-9">
+        <div class="row middle-xs page-header">
+          <div class="col-xs-6 col-sm-9 col-md-10 page-title">
+            <%= term.name %>
           </div>
-        <% end %>
-      <% end %>
+        </div>
+      </div>
+      <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp page">
+        <thead>
+          <tr>
+            <th>Class date</th>
+            <th>Starting at</th>
+            <th>Finishes at</th>
+            <th>Classroom</th>
+            <%= if @conn.assigns.current_user.role == "Coordinator" do %>
+              <th></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for offered_course <- term.offered_courses do %>
+            <td class="mdl-data-table__cell--non-numeric">
+              <b><%= offered_course.course.name %></b>
+            </td>
+            <%= Enum.with_index(offered_course.classes) |> Enum.map(fn {class,index} -> %>
+              <tr>
+                <td>
+                  <%= class.date %>
+                </td>
+                <td>
+                  <%= class.date
+                      |> Ecto.DateTime.from_date_and_time(class.starting_at)
+                      |> Timex.format!("{h24}:{m}") %>
+                </td>
+                <td>
+                  <%= class.date
+                      |> Ecto.DateTime.from_date_and_time(class.finishes_at)
+                      |> Timex.format!("{h24}:{m}") %>
+                </td>
+                <td>
+                  <%= class.classroom %>
+                </td>
+                <%= if @conn.assigns.current_user.role == "Coordinator" do %>
+                  <td>
+                    <button id="tr_menu_<%= class.id %>"
+                            class="mdl-button mdl-js-button mdl-button--icon"
+                    >
+                      <i class="material-icons">more_vert</i>
+                    </button>
+                    <ul
+                      class="
+                        mdl-menu mdl-js-menu
+                        <%=
+                          if index > 10 and index > length(@classes)-4 do
+                            'mdl-menu--top-right'
+                          else
+                            'mdl-menu--bottom-right'
+                          end
+                        %>
+                      "
+                      for="tr_menu_<%= class.id %>"
+                    >
+                      <li class="mdl-menu__item">
+                        <%= link "Edit", to: class_path(@conn, :edit, class) %>
+                      </li>
+                      <li class="mdl-menu__item">
+                        <%= link "Delete", to: class_path(@conn, :delete, class), method: :delete,
+                          data: [confirm: """
+                          Are you sure?
+                          All the attendances of that class will be removed.
+                          """] %>
+                      </li>
+                    </ul>
+                  </td>
+                <% end %>
+              </tr>
+            <% end) %>
+          <% end %>
+        </tbody>
+      </table>
     </div>
   <% end %>


### PR DESCRIPTION
1 - create different sections for classes based on terms and offered courses
2 - sort classes with the following order : term date, class date, class starting time and class finishing time


Ideally the same needs to be done for the offered_courses index page and attendance index page
with the difference that they just need to be separate based on Terms. but they can be done in a separate PR