### PR TITLE
Fixes wrong attendance order

### DIFF
--- a/lib/course_planner/attendances/attendances.ex
+++ b/lib/course_planner/attendances/attendances.ex
@@ -31,7 +31,7 @@ defmodule CoursePlanner.Attendances do
       join: a in assoc(c,  :attendances),
       join: as in assoc(a, :student),
       join: ac in assoc(a, :class),
-      preload: [:term, :course, teachers: s, students: t],
+      preload: [:term, :course, teachers: t, students: s],
       preload: [classes: {c, students: cs, attendances: {a, student: as, class: ac}}],
       where: oc.id == ^offered_course_id and t.id == ^teacher_id,
       order_by: [asc: ac.date, asc: s.name, asc: s.family_name])

--- a/lib/course_planner/attendances/attendances.ex
+++ b/lib/course_planner/attendances/attendances.ex
@@ -12,13 +12,14 @@ defmodule CoursePlanner.Attendances do
     Repo.one(from oc in OfferedCourse,
       join: s in assoc(oc, :students),
       join: c in assoc(oc, :classes),
+      join: cs in assoc(c, :students),
       join: a in assoc(c,  :attendances),
       join: as in assoc(a, :student),
       join: ac in assoc(a, :class),
       preload: [:term, :course, :teachers, :students],
-      preload: [classes: {c, attendances: {a, student: as, class: ac}}],
+      preload: [classes: {c, students: cs, attendances: {a, student: as, class: ac}}],
       where: oc.id == ^offered_course_id,
-      order_by: [asc: ac.date, asc: s.name, asc: s.family_name])
+      order_by: [asc: ac.date, asc: as.name, asc: as.family_name])
   end
 
   def get_teacher_course_attendances(offered_course_id, teacher_id) do
@@ -26,11 +27,12 @@ defmodule CoursePlanner.Attendances do
       join: t in assoc(oc, :teachers),
       join: s in assoc(oc, :students),
       join: c in assoc(oc, :classes),
+      join: cs in assoc(c, :students),
       join: a in assoc(c,  :attendances),
       join: as in assoc(a, :student),
       join: ac in assoc(a, :class),
-      preload: [:term, :course, teachers: t, students: s],
-      preload: [classes: {c, attendances: {a, student: as, class: ac}}],
+      preload: [:term, :course, teachers: s, students: t],
+      preload: [classes: {c, students: cs, attendances: {a, student: as, class: ac}}],
       where: oc.id == ^offered_course_id and t.id == ^teacher_id,
       order_by: [asc: ac.date, asc: s.name, asc: s.family_name])
   end

--- a/lib/course_planner/attendances/attendances.ex
+++ b/lib/course_planner/attendances/attendances.ex
@@ -27,10 +27,12 @@ defmodule CoursePlanner.Attendances do
       join: s in assoc(oc, :students),
       join: c in assoc(oc, :classes),
       join: a in assoc(c,  :attendances),
+      join: as in assoc(a, :student),
+      join: ac in assoc(a, :class),
       preload: [:term, :course, teachers: t, students: s],
-      preload: [classes: {c, attendances: a}],
+      preload: [classes: {c, attendances: {a, student: as, class: ac}}],
       where: oc.id == ^offered_course_id and t.id == ^teacher_id,
-      order_by: [asc: c.date])
+      order_by: [asc: ac.date, asc: s.name, asc: s.family_name])
   end
 
   def get_student_attendances(offered_course_id, student_id) do

--- a/lib/course_planner_web/templates/attendance/fill_course_attendance.html.eex
+++ b/lib/course_planner_web/templates/attendance/fill_course_attendance.html.eex
@@ -42,7 +42,7 @@
                 <table class="attendance-table">
                   <thead>
                     <tr class="attendance-table__thead-tr">
-                      <%= for student <- @offered_course.students do %>
+                      <%= for student <- CoursePlannerWeb.AttendanceView.get_offered_course_students(@offered_course) do %>
                         <th class="attendance-table__th">
                           <div class="attendance-table__th-wrapper">
                             <div class="attendance-table__profile-picture">

--- a/lib/course_planner_web/templates/attendance/show_coordinator.html.eex
+++ b/lib/course_planner_web/templates/attendance/show_coordinator.html.eex
@@ -45,7 +45,7 @@
                 <table class="attendance-table">
                   <thead>
                     <tr class="attendance-table__thead-tr">
-                      <%= for student <- @offered_course.students do %>
+                      <%= for student <- CoursePlannerWeb.AttendanceView.get_offered_course_students(@offered_course) do %>
                         <th class="attendance-table__th">
                           <div class="attendance-table__th-wrapper">
                             <div class="attendance-table__profile-picture">

--- a/lib/course_planner_web/views/attendance_view.ex
+++ b/lib/course_planner_web/views/attendance_view.ex
@@ -21,4 +21,12 @@ defmodule CoursePlannerWeb.AttendanceView do
     |> Map.new(fn (option) -> {option, option} end)
     |> Map.merge(%{"Not set": ""})
   end
+
+  def get_offered_course_students(offered_course) do
+    one_class =
+      offered_course.classes
+      |> List.first()
+
+    Enum.map(one_class.attendances, &(&1.student))
+  end
 end


### PR DESCRIPTION
ordering was forgotten to be added for the teacher and was just added for the coordinator. this commit ensures the ordering based on the student name and family_name to be added for the teacher as well

root cause :
in the show we use "get_teacher_course_attendances" while in fill we use "get_course_attendances" function to retrive all the attendances. both have to have the same sorting order so the rendered order of the students and attendance be the same

The same problem won't happen for student cause he only sees his own attendance and need no sorting on name or family_name