### PR TITLE
Fixes password length check when user updates itself

### DIFF
--- a/lib/course_planner/accounts/user.ex
+++ b/lib/course_planner/accounts/user.ex
@@ -148,7 +148,7 @@ defmodule CoursePlanner.Accounts.User do
 
     if password do
       changeset
-      |> validate_length(:password, min: 6)
+      |> validate_length(:password, min: 8)
       |> validate_confirmation(:password)
       |> updates_hashed_password()
     else

--- a/test/course_planner_web/controllers/user_controller_test.exs
+++ b/test/course_planner_web/controllers/user_controller_test.exs
@@ -206,6 +206,15 @@ defmodule CoursePlanner.UserControllerTest do
     assert Repo.get_by(User, email: "foo@bar.com")
   end
 
+  test "does not update password if is too short" do
+    user = insert(:student, name: "Foo", family_name: "Bar")
+    user_conn = guardian_login_html(user)
+
+    conn = put user_conn, user_path(user_conn, :update, user), %{"user" => %{"current_password" => "secret", "password" => "123456", "password_confirmation" => "123456"}}
+
+    assert html_response(conn, 200) =~ "should be at least 8 character(s)"
+  end
+
   test "notify all users" do
     user_conn = login_as(:coordinator)
 

--- a/test/course_planner_web/controllers/user_controller_test.exs
+++ b/test/course_planner_web/controllers/user_controller_test.exs
@@ -207,8 +207,7 @@ defmodule CoursePlanner.UserControllerTest do
   end
 
   test "does not update password if is too short" do
-    user = insert(:student, name: "Foo", family_name: "Bar")
-    user_conn = guardian_login_html(user)
+    %{assigns: %{current_user: user}} = user_conn = login_as(:student)
 
     conn = put user_conn, user_path(user_conn, :update, user), %{"user" => %{"current_password" => "secret", "password" => "123456", "password_confirmation" => "123456"}}
 


### PR DESCRIPTION
password limit of 8 character was just being checked on password reset page and not on user update page ( it was wrongly still on 6 characters )